### PR TITLE
Fix a rare crash involving subpath relativity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,11 @@
 
 ### Added
 
-- More robust SVG → vector conversions by Android Studio tools
+- More robust SVG → vector conversions by Android Studio tools (#47)
+
+### Fixed
+
+- In rare cases, subpath start points were tracked incorrectly which resulted in a crash (#57)
 
 ## 2.1.0 - 09-14-2021 
 

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BreakoutImplicitCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BreakoutImplicitCommands.kt
@@ -19,7 +19,7 @@ import com.jzbrooks.vgo.core.graphic.command.SmoothQuadraticBezierCurve
 import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
 
 /**
- * Enables more resolution in the the other command
+ * Enables more resolution in the other command
  * related optimizations like [CommandVariant] and [RemoveRedundantCommands]
  */
 class BreakoutImplicitCommands : TopDownOptimization {

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CommandVariant.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CommandVariant.kt
@@ -5,8 +5,8 @@ import com.jzbrooks.vgo.core.graphic.Extra
 import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.graphic.Group
 import com.jzbrooks.vgo.core.graphic.Path
-import com.jzbrooks.vgo.core.graphic.command.Command
 import com.jzbrooks.vgo.core.graphic.command.ClosePath
+import com.jzbrooks.vgo.core.graphic.command.Command
 import com.jzbrooks.vgo.core.graphic.command.CommandPrinter
 import com.jzbrooks.vgo.core.graphic.command.CommandVariant
 import com.jzbrooks.vgo.core.graphic.command.CubicBezierCurve
@@ -20,7 +20,6 @@ import com.jzbrooks.vgo.core.graphic.command.SmoothCubicBezierCurve
 import com.jzbrooks.vgo.core.graphic.command.SmoothQuadraticBezierCurve
 import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
 import com.jzbrooks.vgo.core.util.math.Point
-
 
 /**
  * Converts commands to use relative, absolute,
@@ -70,18 +69,19 @@ class CommandVariant(private val mode: Mode) : TopDownOptimization {
                 pathStart.addFirst(currentPoint.copy())
             }
 
-            val modifiedCommand = when (command) {
-                is MoveTo -> process(command)
-                is LineTo -> process(command)
-                is HorizontalLineTo -> process(command)
-                is VerticalLineTo -> process(command)
-                is CubicBezierCurve -> process(command)
-                is SmoothCubicBezierCurve -> process(command)
-                is QuadraticBezierCurve -> process(command)
-                is SmoothQuadraticBezierCurve -> process(command)
-                is EllipticalArcCurve -> process(command)
-                is ClosePath -> process(command)
-            }
+            val modifiedCommand =
+                when (command) {
+                    is MoveTo -> process(command)
+                    is LineTo -> process(command)
+                    is HorizontalLineTo -> process(command)
+                    is VerticalLineTo -> process(command)
+                    is CubicBezierCurve -> process(command)
+                    is SmoothCubicBezierCurve -> process(command)
+                    is QuadraticBezierCurve -> process(command)
+                    is SmoothQuadraticBezierCurve -> process(command)
+                    is EllipticalArcCurve -> process(command)
+                    is ClosePath -> process(command)
+                }
 
             modifiedCommands.add(modifiedCommand)
         }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CommandVariant.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CommandVariant.kt
@@ -83,10 +83,6 @@ class CommandVariant(private val mode: Mode) : TopDownOptimization {
                 is ClosePath -> process(command)
             }
 
-            if (previousCommand is ClosePath && command is MoveTo) {
-                pathStart.addFirst(currentPoint.copy())
-            }
-
             modifiedCommands.add(modifiedCommand)
         }
 
@@ -112,6 +108,8 @@ class CommandVariant(private val mode: Mode) : TopDownOptimization {
                         }.also { currentPoint += it.last() },
                 )
             }
+
+        pathStart.addFirst(currentPoint.copy())
 
         return choose(convertedCommand, command)
     }
@@ -293,7 +291,7 @@ class CommandVariant(private val mode: Mode) : TopDownOptimization {
                     variant = CommandVariant.ABSOLUTE,
                     parameters =
                         command.parameters.map { commandPoint ->
-                            (commandPoint + currentPoint)
+                            commandPoint + currentPoint
                         }.also { currentPoint = it.last().copy() },
                 )
             } else {
@@ -301,7 +299,7 @@ class CommandVariant(private val mode: Mode) : TopDownOptimization {
                     variant = CommandVariant.RELATIVE,
                     parameters =
                         command.parameters.map { commandPoint ->
-                            (commandPoint - currentPoint)
+                            commandPoint - currentPoint
                         }.also {
                             currentPoint += it.last()
                         },

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/Commands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/Commands.kt
@@ -13,7 +13,6 @@ import com.jzbrooks.vgo.core.graphic.command.QuadraticBezierCurve
 import com.jzbrooks.vgo.core.graphic.command.SmoothCubicBezierCurve
 import com.jzbrooks.vgo.core.graphic.command.SmoothQuadraticBezierCurve
 import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
-import java.util.Stack
 
 /**
  * Computes absolute coordinates for a given command in the sequence.

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/math/CommandsTest.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/math/CommandsTest.kt
@@ -61,6 +61,25 @@ class CommandsTest {
 
         val absoluteCoordinates = computeAbsoluteCoordinates(commands.take(6))
 
-        assertThat(absoluteCoordinates).isEqualTo(Point(12f, 8f))
+        assertThat(absoluteCoordinates).isEqualTo(Point(20f, 1f))
+    }
+
+    @Test
+    fun `Closing a subpath after a non-moveto command returns to previous coordinate`() {
+        val commands =
+            listOf(
+                MoveTo(CommandVariant.ABSOLUTE, listOf(Point(10f, 1f))),
+                LineTo(CommandVariant.RELATIVE, listOf(Point(-9f, 6f))),
+                MoveTo(CommandVariant.RELATIVE, listOf(Point(1f, 1f))),
+                LineTo(CommandVariant.RELATIVE, listOf(Point(3f, 7f))),
+                ClosePath,
+                HorizontalLineTo(CommandVariant.RELATIVE, listOf(10f)),
+                VerticalLineTo(CommandVariant.RELATIVE, listOf(-4f)),
+                ClosePath,
+            )
+
+        val absoluteCoordinates = computeAbsoluteCoordinates(commands)
+
+        assertThat(absoluteCoordinates).isEqualTo(Point(10f, 1f))
     }
 }


### PR DESCRIPTION
This is super important for calculating relative coordinates for a given subpath and it was totally wrong in a couple spots.

> If a "closepath" is followed immediately by a "moveto", then the "moveto" identifies the start point of the next subpath. If a "closepath" is followed immediately by any other command, then the next subpath starts at the same initial point as the current subpath.

https://www.w3.org/TR/SVG/paths.html#PathDataClosePathCommand
