### PR TITLE
Ensure intersection point of lines lies on given segments

### DIFF
--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/ConvertCurvesToArcs.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/ConvertCurvesToArcs.kt
@@ -20,7 +20,7 @@ import com.jzbrooks.vgo.core.util.math.liesOnCircle
 import com.jzbrooks.vgo.core.util.math.toCubicBezierCurve
 
 /**
- * Converts cubic bezier curves to arcs, when they are shorter.
+ * Converts cubic Bézier curves to arcs, when they are shorter.
  */
 class ConvertCurvesToArcs(private val printer: CommandPrinter) : TopDownOptimization {
     override fun visit(graphic: Graphic) {}
@@ -148,7 +148,7 @@ class ConvertCurvesToArcs(private val printer: CommandPrinter) : TopDownOptimiza
                     }
 
                     // If the next curve is a shorthand, it must be converted
-                    // to longhand if it the previous curve is replaced with an
+                    // to longhand if the previous curve is replaced with an
                     // elliptical arc.
                     if (nextCommand is SmoothCubicBezierCurve) {
                         ellipticalArcs.add(nextCommand.toCubicBezierCurve(pendingCurves.last()))
@@ -191,7 +191,7 @@ class ConvertCurvesToArcs(private val printer: CommandPrinter) : TopDownOptimiza
                 assert(command.parameters.size == 1)
 
                 val currentParameter = command.parameters[0]
-                val circle = command.fitCircle(1e-2f)
+                val circle = command.fitCircle()
                 if (circle != null && command.isConvex()) {
                     val radius = circle.radius
                     val sweep =

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/Curves.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/Curves.kt
@@ -90,10 +90,10 @@ fun CubicCurve<*>.isConvex(tolerance: Float = 1e-3f): Boolean {
     val intersection = secondDiagonal.intersection(firstDiagonal, tolerance)
 
     return intersection != null &&
-        endControl.x < intersection.x == intersection.x < 0 &&
-        endControl.y < intersection.y == intersection.y < 0 &&
-        end.x < intersection.x == intersection.x < startControl.x &&
-        end.y < intersection.y == intersection.y < startControl.y
+            endControl.x < intersection.x && intersection.x < 0 &&
+            endControl.y < intersection.y && intersection.y < 0 &&
+            end.x < intersection.x && intersection.x < startControl.x &&
+            end.y < intersection.y && intersection.y < startControl.y
 }
 
 /**
@@ -125,11 +125,10 @@ fun CubicCurve<*>.liesOnCircle(
     circle: Circle,
     tolerance: Float = 1e-3f,
 ): Boolean {
-    @Suppress("NAME_SHADOWING")
-    val tolerance = min(ARC_THRESHOLD * tolerance, ARC_TOLERANCE * circle.radius / 100)
+    val finalTolerance = min(ARC_THRESHOLD * tolerance, ARC_TOLERANCE * circle.radius / 100)
 
     return floatArrayOf(0f, 0.25f, 0.5f, 0.75f, 1f).all { t ->
-        abs(interpolate(t).distanceTo(circle.center) - circle.radius) <= tolerance
+        abs(interpolate(t).distanceTo(circle.center) - circle.radius) <= finalTolerance
     }
 }
 

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/LineSegment.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/LineSegment.kt
@@ -1,6 +1,6 @@
 package com.jzbrooks.vgo.core.util.math
 
-import kotlin.math.abs
+import kotlin.math.absoluteValue
 
 data class LineSegment(val first: Point, val second: Point) {
     fun intersection(
@@ -8,23 +8,51 @@ data class LineSegment(val first: Point, val second: Point) {
         tolerance: Float = 1e-3f,
     ): Point? {
         // this represented as a1x + b1y = c1
-        val a1 = this.second.y - this.first.y
-        val b1 = this.first.x - this.second.x
-        val c1 = a1 * this.first.x + b1 * this.first.y
+        val a1 = second.y - first.y
+        val b1 = first.x - second.x
+        val c1 = a1 * first.x + b1 * first.y
 
-        // second represented as a1x + b1y = c1
+        // second represented as a2x + b2y = c2
         val a2 = other.second.y - other.first.y
         val b2 = other.first.x - other.second.x
         val c2 = a2 * other.first.x + b2 * other.first.y
 
         val determinant = a1 * b2 - a2 * b1
-        if (abs(determinant) <= tolerance) {
+        if (determinant.absoluteValue <= tolerance) {
             return null
         }
 
         val x = (b2 * c1 - b1 * c2) / determinant
         val y = (a1 * c2 - a2 * c1) / determinant
 
-        return Point(x, y)
+        val intersectionPoint = Point(x, y)
+
+        if (contains(intersectionPoint, tolerance) &&
+            other.contains(intersectionPoint, tolerance)) {
+            return intersectionPoint
+        }
+
+        return null
+    }
+
+    private fun contains(point: Point, tolerance: Float): Boolean {
+        // If the cross product is non-zero, then the lines are not collinear
+        val cross = (point.y - first.y) * (second.x - first.x) -
+                (point.x - first.x) * (second.y - first.y)
+
+        if (cross.absoluteValue > tolerance) return false
+
+        // If the dot product is less than zero or greater than
+        // the squared length of the segment, then the point is
+        // collinear _but_ does not lie on the line segment
+        val dot = (point.x - first.x) * (second.x - first.x) +
+                (point.y - first.y) * (second.y - first.y)
+
+        if (dot < 0) return false
+
+        val squaredLength = (second.x - first.x) * (second.x - first.x) +
+                (second.y - first.y) * (second.y - first.y)
+
+        return dot <= squaredLength
     }
 }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/LineSegment.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/LineSegment.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.util.math
+ package com.jzbrooks.vgo.core.util.math
 
 import kotlin.math.absoluteValue
 
@@ -27,24 +27,21 @@ data class LineSegment(val first: Point, val second: Point) {
 
         val intersectionPoint = Point(x, y)
 
-        if (contains(intersectionPoint, tolerance) &&
-            other.contains(intersectionPoint, tolerance)) {
+        if (contains(intersectionPoint) && other.contains(intersectionPoint)) {
             return intersectionPoint
         }
 
         return null
     }
 
-    private fun contains(point: Point, tolerance: Float): Boolean {
-        // If the cross product is non-zero, then the lines are not collinear
-        val cross = (point.y - first.y) * (second.x - first.x) -
-                (point.x - first.x) * (second.y - first.y)
-
-        if (cross.absoluteValue > tolerance) return false
-
-        // If the dot product is less than zero or greater than
-        // the squared length of the segment, then the point is
-        // collinear _but_ does not lie on the line segment
+    // If the dot product is less than zero or greater than
+    // the squared length of the segment, then the point is
+    // collinear _but_ does not lie on the line segment
+    //
+    // Collinearity checks are skipped since we already know
+    // the intersection point lies on the line segments
+    // because they intersect each other
+    private fun contains(point: Point): Boolean {
         val dot = (point.x - first.x) * (second.x - first.x) +
                 (point.y - first.y) * (second.y - first.y)
 

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/Point.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/math/Point.kt
@@ -26,7 +26,7 @@ data class Point(val x: Float, val y: Float) {
 
     fun isApproximately(
         other: Point,
-        error: Float = 0.001f,
+        error: Float = 1e-3f,
     ): Boolean {
         return (x - other.x).absoluteValue < error && (y - other.y).absoluteValue < error
     }

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/math/LineSegmentTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/math/LineSegmentTests.kt
@@ -1,8 +1,8 @@
 package com.jzbrooks.vgo.core.util.math
 
+import assertk.all
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isNull
+import assertk.assertions.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -14,7 +14,10 @@ class LineSegmentTests {
 
         val actual = first.intersection(second)
 
-        assertThat(actual).isEqualTo(result)
+        assertThat(actual).isNotNull().all {
+            prop(Point::x).isCloseTo(result.x, 1e-3f)
+            prop(Point::y).isCloseTo(result.y, 1e-3f)
+        }
     }
 
     @MethodSource
@@ -27,7 +30,17 @@ class LineSegmentTests {
         assertThat(actual).isNull()
     }
 
-    data class Intersection(val first: LineSegment, val second: LineSegment, val result: Point?)
+    @MethodSource
+    @ParameterizedTest
+    fun testNonParallelDisjointSegmentsReturnsNull(pair: Pair<LineSegment, LineSegment>) {
+        val (first, second) = pair
+
+        val actual = first.intersection(second)
+
+        assertThat(actual).isNull()
+    }
+
+    data class Intersection(val first: LineSegment, val second: LineSegment, val result: Point)
 
     companion object {
         @JvmStatic
@@ -39,9 +52,9 @@ class LineSegmentTests {
                     Point.ZERO,
                 ),
                 Intersection(
-                    LineSegment(Point(1f, 1f), Point(4f, 4f)),
-                    LineSegment(Point(1f, 8f), Point(2f, 4f)),
-                    Point(2.4f, 2.4f),
+                    LineSegment(Point(-1f, 2f), Point(2f, -2f)),
+                    LineSegment(Point(-1f, -2f), Point(2f, 2f)),
+                    Point(0.5f, 0f),
                 ),
             )
         }
@@ -50,6 +63,13 @@ class LineSegmentTests {
         fun testParallelLinesReturnsNull(): List<Pair<LineSegment, LineSegment>> {
             return listOf(
                 LineSegment(Point(0f, 3f), Point(0f, 3f)) to LineSegment(Point(1f, 3f), Point(1f, 3f)),
+            )
+        }
+
+        @JvmStatic
+        fun testNonParallelDisjointSegmentsReturnsNull(): List<Pair<LineSegment, LineSegment>> {
+            return listOf(
+                LineSegment(Point(1f, 1f), Point(4f, 4f)) to LineSegment(Point(1f, 8f), Point(2f, 4f))
             )
         }
     }


### PR DESCRIPTION
The calculation for line intersection was correct, but the intersection point wasn't ensured to lie on both of the line segments. So the calculation was incorrect.

Fixes #60