### PR TITLE
Avoid hanging on projects with no resources

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,17 +2,9 @@
 
 ## Unreleased
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
 
-### Security
+- Gradle plugin hangs for projects with no vector drawables
 
 ## 2.2.0 - 2024-08-13
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-XX:+UseParallelGC
 
 GROUP=com.jzbrooks
-VERSION_NAME=2.2.0
+VERSION_NAME=2.2.1
 
 POM_URL=https://github.com/jzbrooks/vgo/
 

--- a/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/ShrinkVectorArtwork.kt
+++ b/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/ShrinkVectorArtwork.kt
@@ -34,9 +34,12 @@ open class ShrinkVectorArtwork : DefaultTask() {
 
     @TaskAction
     fun shrink() {
-        val argList = mutableListOf<String>()
+        val argList = files.toMutableList()
 
-        argList.addAll(files)
+        if (argList.isEmpty()) {
+            logger.info("No files to shrink")
+            return
+        }
 
         if (indent != 0.toByte()) {
             argList.addAll(arrayOf("--indent", indent.toString()))


### PR DESCRIPTION
When the default filetree (or specified filetree) is empty, Application.run is passed an argument list with no input files. When vgo runs without explict inputs, it waits for stdin inputs. So it appears to hang for gradle projects with no matches.