### PR TITLE
Fix parallel execution of shrinkVectorArtwork

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - A bug that would sometimes introduce a grouping comma into a large number, breaking path data. This most often occurred in the convert curves to arcs optimization when an arc with a large radius was more compact than the corresponding Bézier curve. 
+- Thread safety issues that prevented the `shrinkVectorArtwork` task from being executed in parallel in a highly-modularized parallel Gradle build.
 
 ## 2.2.2 - 2024-08-30
 

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
@@ -14,27 +14,24 @@ import com.jzbrooks.vgo.core.optimization.RemoveTransparentPaths
 import com.jzbrooks.vgo.core.optimization.SimplifyBezierCurveCommands
 import com.jzbrooks.vgo.core.optimization.SimplifyLineCommands
 
-class SvgOptimizationRegistry : OptimizationRegistry(BOTTOM_UP, TOP_DOWN) {
-    companion object {
-        private val BOTTOM_UP =
-            listOf(
-                BakeTransformations(),
-                CollapseGroups(),
-                RemoveEmptyGroups(),
-                MergePaths(),
-            )
-
-        private val TOP_DOWN =
-            listOf(
-                RemoveTransparentPaths(),
-                BreakoutImplicitCommands(),
-                CommandVariant(CommandVariant.Mode.Relative),
-                SimplifyLineCommands(1e-3f),
-                ConvertCurvesToArcs(ScalableVectorGraphicCommandPrinter(3)),
-                SimplifyBezierCurveCommands(1e-3f),
-                RemoveRedundantCommands(),
-                CommandVariant(CommandVariant.Mode.Compact(ScalableVectorGraphicCommandPrinter(3))),
-                Polycommands(),
-            )
-    }
-}
+class SvgOptimizationRegistry : OptimizationRegistry(
+    bottomUpOptimizations =
+        listOf(
+            BakeTransformations(),
+            CollapseGroups(),
+            RemoveEmptyGroups(),
+            MergePaths(),
+        ),
+    topDownOptimizations =
+        listOf(
+            RemoveTransparentPaths(),
+            BreakoutImplicitCommands(),
+            CommandVariant(CommandVariant.Mode.Relative),
+            SimplifyLineCommands(1e-3f),
+            ConvertCurvesToArcs(ScalableVectorGraphicCommandPrinter(3)),
+            SimplifyBezierCurveCommands(1e-3f),
+            RemoveRedundantCommands(),
+            CommandVariant(CommandVariant.Mode.Compact(ScalableVectorGraphicCommandPrinter(3))),
+            Polycommands(),
+        ),
+)

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
@@ -14,27 +14,24 @@ import com.jzbrooks.vgo.core.optimization.RemoveTransparentPaths
 import com.jzbrooks.vgo.core.optimization.SimplifyBezierCurveCommands
 import com.jzbrooks.vgo.core.optimization.SimplifyLineCommands
 
-class VectorDrawableOptimizationRegistry : OptimizationRegistry(BOTTOM_UP, TOP_DOWN) {
-    companion object {
-        private val BOTTOM_UP =
-            listOf(
-                BakeTransformations(),
-                CollapseGroups(),
-                RemoveEmptyGroups(),
-                MergePaths(),
-            )
-
-        private val TOP_DOWN =
-            listOf(
-                RemoveTransparentPaths(),
-                BreakoutImplicitCommands(),
-                CommandVariant(CommandVariant.Mode.Relative),
-                SimplifyLineCommands(1e-3f),
-                ConvertCurvesToArcs(VectorDrawableCommandPrinter(3)),
-                SimplifyBezierCurveCommands(1e-3f),
-                RemoveRedundantCommands(),
-                CommandVariant(CommandVariant.Mode.Compact(VectorDrawableCommandPrinter(3))),
-                Polycommands(),
-            )
-    }
-}
+class VectorDrawableOptimizationRegistry : OptimizationRegistry(
+    bottomUpOptimizations =
+        listOf(
+            BakeTransformations(),
+            CollapseGroups(),
+            RemoveEmptyGroups(),
+            MergePaths(),
+        ),
+    topDownOptimizations =
+        listOf(
+            RemoveTransparentPaths(),
+            BreakoutImplicitCommands(),
+            CommandVariant(CommandVariant.Mode.Relative),
+            SimplifyLineCommands(1e-3f),
+            ConvertCurvesToArcs(VectorDrawableCommandPrinter(3)),
+            SimplifyBezierCurveCommands(1e-3f),
+            RemoveRedundantCommands(),
+            CommandVariant(CommandVariant.Mode.Compact(VectorDrawableCommandPrinter(3))),
+            Polycommands(),
+        ),
+)


### PR DESCRIPTION
This is the effective solution to the parallelism problem that 417ee421f6a41e1c46293c9be8c780800e9465be aimed to solve. The latter may be reverted at some point.
