### PR TITLE
Keep class used in EnumMap

### DIFF
--- a/vgo-cli/optimize.pro
+++ b/vgo-cli/optimize.pro
@@ -8,3 +8,6 @@
 -keep class com.jzbrooks.vgo.cli.CommandLineInterface {
   public static void main(java.lang.String[]);
 }
+
+# Used in an EnumMap inside tools-sdk code. It is required for converting vectors with clip paths.
+-keep,allowoptimization enum com.android.ide.common.vectordrawable.SvgNode$ClipRule


### PR DESCRIPTION
Fixes #102 

https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:sdk-common/src/main/java/com/android/ide/common/vectordrawable/SvgClipPathNode.java;l=140

If this class is stripped, the enum map constructor will throw an exception.