### PR TITLE
Parse arc flag parameter shorthand

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,17 +2,8 @@
 
 ## Unreleased
 
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
 ### Fixed
-
-### Security
+- Incorrect parsing of elliptical arc parameters when no separator was present between flag parameters
 
 ## 3.0.0 - 2024-11-30
 

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/graphic/command/CommandString.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/graphic/command/CommandString.kt
@@ -109,10 +109,16 @@ value class CommandString(
                             number
                                 .findAll(command)
                                 .map(MatchResult::value)
-                                .map(String::toFloat)
                                 .chunked(7)
+                                .map {
+                                    if (it.size == 6) {
+                                        it.take(3).map { it.toFloat() } + it[3].map { it.toString().toFloat() } +
+                                            it.drop(4).map { it.toFloat() }
+                                    } else {
+                                        it.map { it.toFloat() }
+                                    }
+                                }.toList()
                                 .map(::mapEllipticalArcCurveParameter)
-                                .toList()
 
                         EllipticalArcCurve(variant, parameters)
                     }

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/graphic/command/ParserTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/graphic/command/ParserTests.kt
@@ -5,12 +5,14 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.containsOnly
+import assertk.assertions.first
 import assertk.assertions.hasClass
 import assertk.assertions.index
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
 import com.jzbrooks.vgo.core.util.math.Point
+import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle.parameters
 import org.junit.jupiter.api.Test
 
 class ParserTests {
@@ -201,6 +203,30 @@ class ParserTests {
     }
 
     @Test
+    fun testArcParameterWithoutCommaBetweenFlags() {
+        val pathCommandString = "M1,1 A 1,1,0,01,3,3"
+
+        val commands = CommandString(pathCommandString).toCommandList()
+
+        assertThat(commands).containsExactly(
+            moveToSingle,
+            EllipticalArcCurve(
+                CommandVariant.ABSOLUTE,
+                listOf(
+                    EllipticalArcCurve.Parameter(
+                        1f,
+                        1f,
+                        0f,
+                        EllipticalArcCurve.ArcFlag.SMALL,
+                        EllipticalArcCurve.SweepFlag.CLOCKWISE,
+                        Point(3f, 3f),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun testParseRelativeCommandString() {
         val pathCommandString = "l2 5"
 
@@ -220,7 +246,7 @@ class ParserTests {
 
         val lineCommand = commands[0] as LineTo
 
-        assertThat(lineCommand.parameters[0]).isEqualTo(Point(2.1f, 5f))
+        assertThat(lineCommand::parameters).first().isEqualTo(Point(2.1f, 5f))
     }
 
     @Test
@@ -231,7 +257,7 @@ class ParserTests {
 
         val lineCommand = commands[0] as LineTo
 
-        assertThat(lineCommand.parameters[0]).isEqualTo(Point(200f, 5f))
+        assertThat(lineCommand::parameters).first().isEqualTo(Point(200f, 5f))
     }
 
     @Test

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/graphic/command/ParserTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/graphic/command/ParserTests.kt
@@ -12,7 +12,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
 import com.jzbrooks.vgo.core.util.math.Point
-import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle.parameters
 import org.junit.jupiter.api.Test
 
 class ParserTests {

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/graphic/command/ParserTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/graphic/command/ParserTests.kt
@@ -227,6 +227,38 @@ class ParserTests {
     }
 
     @Test
+    fun testMultipleArcParametersWithoutCommaBetweenFlags() {
+        val pathCommandString = "M1,1 A 1,1,0,01,3,3 2,2,0,10,4,4"
+
+        val commands = CommandString(pathCommandString).toCommandList()
+
+        assertThat(commands).containsExactly(
+            moveToSingle,
+            EllipticalArcCurve(
+                CommandVariant.ABSOLUTE,
+                listOf(
+                    EllipticalArcCurve.Parameter(
+                        1f,
+                        1f,
+                        0f,
+                        EllipticalArcCurve.ArcFlag.SMALL,
+                        EllipticalArcCurve.SweepFlag.CLOCKWISE,
+                        Point(3f, 3f),
+                    ),
+                    EllipticalArcCurve.Parameter(
+                        2f,
+                        2f,
+                        0f,
+                        EllipticalArcCurve.ArcFlag.LARGE,
+                        EllipticalArcCurve.SweepFlag.ANTICLOCKWISE,
+                        Point(4f, 4f),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun testParseRelativeCommandString() {
         val pathCommandString = "l2 5"
 


### PR DESCRIPTION
Arc flags aren't necessarily separated by a comma.
https://www.w3.org/TR/SVG11/paths.html#PathDataBNF

Fixes #124
