### PR TITLE
Deprecate the optimization package

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Relocated classes that transform vector IR from `com.jzbrooks.vgo.core.optimization` to `com.jzbrooks.vgo.core.transformation` and renamed some relevant classes. The former package is deprecated in favor of the latter, with a strong 1:1 correspondence between structures (modulo names).
+
 ### Fixed
 - Incorrect parsing of elliptical arc parameters when no separator was present between flag parameters
 

--- a/vgo-core/api/vgo-core.api
+++ b/vgo-core/api/vgo-core.api
@@ -646,7 +646,7 @@ public final class com/jzbrooks/vgo/core/optimization/SimplifyLineCommands : com
 public abstract interface class com/jzbrooks/vgo/core/optimization/TopDownOptimization : com/jzbrooks/vgo/core/graphic/ElementVisitor {
 }
 
-public final class com/jzbrooks/vgo/core/transformation/BakeTransformations : com/jzbrooks/vgo/core/graphic/ElementVisitor, com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+public final class com/jzbrooks/vgo/core/transformation/BakeTransformations : com/jzbrooks/vgo/core/graphic/ElementVisitor, com/jzbrooks/vgo/core/transformation/BottomUpTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -655,10 +655,10 @@ public final class com/jzbrooks/vgo/core/transformation/BakeTransformations : co
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public abstract interface class com/jzbrooks/vgo/core/transformation/BottomUpTransformation : com/jzbrooks/vgo/core/graphic/ElementVisitor {
+public abstract interface class com/jzbrooks/vgo/core/transformation/BottomUpTransformer : com/jzbrooks/vgo/core/graphic/ElementVisitor {
 }
 
-public final class com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -667,7 +667,7 @@ public final class com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/CollapseGroups : com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+public final class com/jzbrooks/vgo/core/transformation/CollapseGroups : com/jzbrooks/vgo/core/transformation/BottomUpTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -676,7 +676,7 @@ public final class com/jzbrooks/vgo/core/transformation/CollapseGroups : com/jzb
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/CommandVariant : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/CommandVariant : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> (Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -713,7 +713,7 @@ public final class com/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Rela
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> (Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -722,7 +722,7 @@ public final class com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs : co
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/MergePaths : com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+public final class com/jzbrooks/vgo/core/transformation/MergePaths : com/jzbrooks/vgo/core/transformation/BottomUpTransformer {
 	public fun <init> ()V
 	public fun <init> (Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints;)V
 	public synthetic fun <init> (Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -756,7 +756,7 @@ public final class com/jzbrooks/vgo/core/transformation/MergePaths$Constraints$P
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/jzbrooks/vgo/core/transformation/Polycommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/Polycommands : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -765,7 +765,7 @@ public final class com/jzbrooks/vgo/core/transformation/Polycommands : com/jzbro
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups : com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+public final class com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups : com/jzbrooks/vgo/core/transformation/BottomUpTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -774,7 +774,7 @@ public final class com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups : com/
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -783,7 +783,7 @@ public final class com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands 
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> ()V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -792,7 +792,7 @@ public final class com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths :
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public fun <init> (F)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
@@ -801,7 +801,7 @@ public final class com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveComma
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public final class com/jzbrooks/vgo/core/transformation/SimplifyLineCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+public final class com/jzbrooks/vgo/core/transformation/SimplifyLineCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformer {
 	public field commands Ljava/util/List;
 	public fun <init> (F)V
 	public final fun getCommands ()Ljava/util/List;
@@ -813,7 +813,7 @@ public final class com/jzbrooks/vgo/core/transformation/SimplifyLineCommands : c
 	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
 }
 
-public abstract interface class com/jzbrooks/vgo/core/transformation/TopDownTransformation : com/jzbrooks/vgo/core/graphic/ElementVisitor {
+public abstract interface class com/jzbrooks/vgo/core/transformation/TopDownTransformer : com/jzbrooks/vgo/core/graphic/ElementVisitor {
 }
 
 public abstract class com/jzbrooks/vgo/core/transformation/TransformerSet {

--- a/vgo-core/api/vgo-core.api
+++ b/vgo-core/api/vgo-core.api
@@ -646,6 +646,181 @@ public final class com/jzbrooks/vgo/core/optimization/SimplifyLineCommands : com
 public abstract interface class com/jzbrooks/vgo/core/optimization/TopDownOptimization : com/jzbrooks/vgo/core/graphic/ElementVisitor {
 }
 
+public final class com/jzbrooks/vgo/core/transformation/BakeTransformations : com/jzbrooks/vgo/core/graphic/ElementVisitor, com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public abstract interface class com/jzbrooks/vgo/core/transformation/BottomUpTransformation : com/jzbrooks/vgo/core/graphic/ElementVisitor {
+}
+
+public final class com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/CollapseGroups : com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/CommandVariant : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> (Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public abstract class com/jzbrooks/vgo/core/transformation/CommandVariant$Mode {
+}
+
+public final class com/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Absolute : com/jzbrooks/vgo/core/transformation/CommandVariant$Mode {
+	public static final field INSTANCE Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Absolute;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Compact : com/jzbrooks/vgo/core/transformation/CommandVariant$Mode {
+	public fun <init> (Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;)V
+	public final fun component1 ()Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;
+	public final fun copy (Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;)Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Compact;
+	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Compact;Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;ILjava/lang/Object;)Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Compact;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrinter ()Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Relative : com/jzbrooks/vgo/core/transformation/CommandVariant$Mode {
+	public static final field INSTANCE Lcom/jzbrooks/vgo/core/transformation/CommandVariant$Mode$Relative;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> (Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/MergePaths : com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+	public fun <init> ()V
+	public fun <init> (Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints;)V
+	public synthetic fun <init> (Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public abstract interface class com/jzbrooks/vgo/core/transformation/MergePaths$Constraints {
+}
+
+public final class com/jzbrooks/vgo/core/transformation/MergePaths$Constraints$None : com/jzbrooks/vgo/core/transformation/MergePaths$Constraints {
+	public static final field INSTANCE Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints$None;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jzbrooks/vgo/core/transformation/MergePaths$Constraints$PathLength : com/jzbrooks/vgo/core/transformation/MergePaths$Constraints {
+	public fun <init> (Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;I)V
+	public final fun component1 ()Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;
+	public final fun component2 ()I
+	public final fun copy (Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;I)Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints$PathLength;
+	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints$PathLength;Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;IILjava/lang/Object;)Lcom/jzbrooks/vgo/core/transformation/MergePaths$Constraints$PathLength;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommandPrinter ()Lcom/jzbrooks/vgo/core/graphic/command/CommandPrinter;
+	public final fun getMaxLength ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jzbrooks/vgo/core/transformation/Polycommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups : com/jzbrooks/vgo/core/transformation/BottomUpTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> ()V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public fun <init> (F)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public final class com/jzbrooks/vgo/core/transformation/SimplifyLineCommands : com/jzbrooks/vgo/core/transformation/TopDownTransformation {
+	public field commands Ljava/util/List;
+	public fun <init> (F)V
+	public final fun getCommands ()Ljava/util/List;
+	public final fun setCommands (Ljava/util/List;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/ClipPath;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+}
+
+public abstract interface class com/jzbrooks/vgo/core/transformation/TopDownTransformation : com/jzbrooks/vgo/core/graphic/ElementVisitor {
+}
+
+public abstract class com/jzbrooks/vgo/core/transformation/TransformerSet {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun apply (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+}
+
 public final class com/jzbrooks/vgo/core/util/element/TraverseKt {
 	public static final fun traverseBottomUp (Lcom/jzbrooks/vgo/core/graphic/Element;Lkotlin/jvm/functions/Function1;)Lcom/jzbrooks/vgo/core/graphic/Element;
 	public static final fun traverseTopDown (Lcom/jzbrooks/vgo/core/graphic/Element;Lkotlin/jvm/functions/Function1;)Lcom/jzbrooks/vgo/core/graphic/Element;

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BakeTransformations.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BakeTransformations.kt
@@ -25,6 +25,7 @@ import java.util.Stack
 /**
  * Apply transformations to paths command coordinates in a group
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.BakeTransformation"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BottomUpOptimization.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BottomUpOptimization.kt
@@ -2,4 +2,8 @@ package com.jzbrooks.vgo.core.optimization
 
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
 
+@Deprecated(
+    "Has been relocated to the transformation package",
+    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.BottomUpTransformation"),
+)
 interface BottomUpOptimization : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BreakoutImplicitCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/BreakoutImplicitCommands.kt
@@ -22,6 +22,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
  * Enables more resolution in the other command
  * related optimizations like [CommandVariant] and [RemoveRedundantCommands]
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.BreakoutImplicitCommands"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CollapseGroups.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CollapseGroups.kt
@@ -11,6 +11,7 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 /**
  * Collapse unnecessary nested groups into a single group
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.CollapseGroups"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CommandVariant.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/CommandVariant.kt
@@ -26,6 +26,7 @@ import com.jzbrooks.vgo.core.util.math.Point
  * or the shortest representation of coordinates
  * @param mode determines the operating mode of the command
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.CommandVariant"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/ConvertCurvesToArcs.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/ConvertCurvesToArcs.kt
@@ -23,6 +23,7 @@ import com.jzbrooks.vgo.core.util.math.toCubicBezierCurve
 /**
  * Converts cubic Bézier curves to arcs, when they are shorter.
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.ConvertCurvesToArcs"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/MergePaths.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/MergePaths.kt
@@ -27,6 +27,7 @@ import com.jzbrooks.vgo.core.util.math.intersects
 /**
  * Merges multiple paths into a single path where possible
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.MergePaths"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/Optimization.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/Optimization.kt
@@ -2,6 +2,7 @@ package com.jzbrooks.vgo.core.optimization
 
 import com.jzbrooks.vgo.core.graphic.Element
 
+@Deprecated("Unused—will be removed in a future release.")
 interface Optimization {
     fun optimize(element: Element)
 }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/OptimizationRegistry.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/OptimizationRegistry.kt
@@ -4,6 +4,7 @@ import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.util.element.traverseBottomUp
 import com.jzbrooks.vgo.core.util.element.traverseTopDown
 
+@Deprecated("Has been relocated to the transformation package", replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.Optimizer"))
 abstract class OptimizationRegistry(
     private val bottomUpOptimizations: List<BottomUpOptimization>,
     private val topDownOptimizations: List<TopDownOptimization>,

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/OptimizationRegistry.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/OptimizationRegistry.kt
@@ -4,6 +4,7 @@ import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.util.element.traverseBottomUp
 import com.jzbrooks.vgo.core.util.element.traverseTopDown
 
+@Suppress("DEPRECATION")
 @Deprecated("Has been relocated to the transformation package", replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.Optimizer"))
 abstract class OptimizationRegistry(
     private val bottomUpOptimizations: List<BottomUpOptimization>,

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/Polycommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/Polycommands.kt
@@ -25,6 +25,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
  * number, you can omit the separator between it and the preceeding
  * pair. It becomes 10,0-1,1.
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.Polycommands"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/RemoveEmptyGroups.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/RemoveEmptyGroups.kt
@@ -11,6 +11,7 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 /**
  * Remove unnecessary groups
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.RemoveEmptyGroups"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/RemoveRedundantCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/RemoveRedundantCommands.kt
@@ -26,6 +26,7 @@ import kotlin.math.absoluteValue
 /**
  * Elide commands that don't contribute to the overall graphic
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.RemoveRedundantCommands"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/RemoveTransparentPaths.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/RemoveTransparentPaths.kt
@@ -7,6 +7,7 @@ import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.graphic.Group
 import com.jzbrooks.vgo.core.graphic.Path
 
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.RemoveTransparentPaths"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/SimplifyBezierCurveCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/SimplifyBezierCurveCommands.kt
@@ -21,6 +21,7 @@ import kotlin.math.sqrt
 /**
  * Convert curves into shorter commands where possible
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.SimplifyBezierCurveCommands"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/SimplifyLineCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/SimplifyLineCommands.kt
@@ -17,6 +17,7 @@ import kotlin.math.sign
 /**
  * Convert lines into shorter commands where possible
  */
+@Suppress("DEPRECATION")
 @Deprecated(
     "Has been relocated to the transformation package",
     replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.SimplifyLineCommands"),

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/TopDownOptimization.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/optimization/TopDownOptimization.kt
@@ -2,4 +2,8 @@ package com.jzbrooks.vgo.core.optimization
 
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
 
+@Deprecated(
+    "Has been relocated to the transformation package",
+    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.TopDownTransformation"),
+)
 interface TopDownOptimization : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BakeTransformations.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BakeTransformations.kt
@@ -27,7 +27,7 @@ import java.util.Stack
  */
 class BakeTransformations :
     ElementVisitor,
-    BottomUpTransformation {
+    BottomUpTransformer {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BakeTransformations.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BakeTransformations.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
@@ -25,13 +25,9 @@ import java.util.Stack
 /**
  * Apply transformations to paths command coordinates in a group
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.BakeTransformation"),
-)
 class BakeTransformations :
     ElementVisitor,
-    BottomUpOptimization {
+    BottomUpTransformation {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BottomUpTransformation.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BottomUpTransformation.kt
@@ -2,4 +2,5 @@ package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
 
+/** This transformation should be applied from the leaf [com.jzbrooks.vgo.core.graphic.Element] to the root */
 interface BottomUpTransformation : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BottomUpTransformation.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BottomUpTransformation.kt
@@ -1,0 +1,5 @@
+package com.jzbrooks.vgo.core.transformation
+
+import com.jzbrooks.vgo.core.graphic.ElementVisitor
+
+interface BottomUpTransformation : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BottomUpTransformer.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BottomUpTransformer.kt
@@ -3,4 +3,4 @@ package com.jzbrooks.vgo.core.transformation
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
 
 /** This transformation should be applied from the leaf [com.jzbrooks.vgo.core.graphic.Element] to the root */
-interface BottomUpTransformation : ElementVisitor
+interface BottomUpTransformer : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands.kt
@@ -22,7 +22,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
  * Enables more resolution in the other command
  * related optimizations like [CommandVariant] and [RemoveRedundantCommands]
  */
-class BreakoutImplicitCommands : TopDownTransformation {
+class BreakoutImplicitCommands : TopDownTransformer {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommands.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -22,11 +22,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
  * Enables more resolution in the other command
  * related optimizations like [CommandVariant] and [RemoveRedundantCommands]
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.BreakoutImplicitCommands"),
-)
-class BreakoutImplicitCommands : TopDownOptimization {
+class BreakoutImplicitCommands : TopDownTransformation {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CollapseGroups.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CollapseGroups.kt
@@ -11,7 +11,7 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 /**
  * Collapse unnecessary nested groups into a single group
  */
-class CollapseGroups : BottomUpTransformation {
+class CollapseGroups : BottomUpTransformer {
     private val Group.isMergeable: Boolean
         get() {
             val hasValidClipPath = elements.any { it is ClipPath }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CollapseGroups.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CollapseGroups.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.ContainerElement
@@ -11,11 +11,7 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 /**
  * Collapse unnecessary nested groups into a single group
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.CollapseGroups"),
-)
-class CollapseGroups : BottomUpOptimization {
+class CollapseGroups : BottomUpTransformation {
     private val Group.isMergeable: Boolean
         get() {
             val hasValidClipPath = elements.any { it is ClipPath }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CommandVariant.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CommandVariant.kt
@@ -28,7 +28,7 @@ import com.jzbrooks.vgo.core.util.math.Point
  */
 class CommandVariant(
     private val mode: Mode,
-) : TopDownTransformation {
+) : TopDownTransformer {
     private val pathStart = ArrayDeque<Point>()
 
     // Updated once per process call when computing

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CommandVariant.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/CommandVariant.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -26,13 +26,9 @@ import com.jzbrooks.vgo.core.util.math.Point
  * or the shortest representation of coordinates
  * @param mode determines the operating mode of the command
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.CommandVariant"),
-)
 class CommandVariant(
     private val mode: Mode,
-) : TopDownOptimization {
+) : TopDownTransformation {
     private val pathStart = ArrayDeque<Point>()
 
     // Updated once per process call when computing

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -23,13 +23,9 @@ import com.jzbrooks.vgo.core.util.math.toCubicBezierCurve
 /**
  * Converts cubic Bézier curves to arcs, when they are shorter.
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.ConvertCurvesToArcs"),
-)
 class ConvertCurvesToArcs(
     private val printer: CommandPrinter,
-) : TopDownOptimization {
+) : TopDownTransformation {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcs.kt
@@ -25,7 +25,7 @@ import com.jzbrooks.vgo.core.util.math.toCubicBezierCurve
  */
 class ConvertCurvesToArcs(
     private val printer: CommandPrinter,
-) : TopDownTransformation {
+) : TopDownTransformer {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/MergePaths.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/MergePaths.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.ContainerElement
@@ -27,13 +27,9 @@ import com.jzbrooks.vgo.core.util.math.intersects
 /**
  * Merges multiple paths into a single path where possible
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.MergePaths"),
-)
 class MergePaths(
     private val constraints: Constraints = Constraints.None,
-) : BottomUpOptimization {
+) : BottomUpTransformation {
     private val surveyor = Surveyor()
 
     override fun visit(graphic: Graphic) = merge(graphic)

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/MergePaths.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/MergePaths.kt
@@ -29,7 +29,7 @@ import com.jzbrooks.vgo.core.util.math.intersects
  */
 class MergePaths(
     private val constraints: Constraints = Constraints.None,
-) : BottomUpTransformation {
+) : BottomUpTransformer {
     private val surveyor = Surveyor()
 
     override fun visit(graphic: Graphic) = merge(graphic)

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/Optimizer.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/Optimizer.kt
@@ -1,0 +1,28 @@
+package com.jzbrooks.vgo.core.transformation
+
+import com.jzbrooks.vgo.core.graphic.Graphic
+import com.jzbrooks.vgo.core.util.element.traverseBottomUp
+import com.jzbrooks.vgo.core.util.element.traverseTopDown
+
+abstract class Optimizer(
+    private val bottomUpTransformations: List<BottomUpTransformation>,
+    private val topDownTransformations: List<TopDownTransformation>,
+) {
+    fun apply(graphic: Graphic) {
+        if (bottomUpTransformations.isNotEmpty()) {
+            traverseBottomUp(graphic) { element ->
+                for (optimization in bottomUpTransformations) {
+                    element.accept(optimization)
+                }
+            }
+        }
+
+        if (topDownTransformations.isNotEmpty()) {
+            traverseTopDown(graphic) { element ->
+                for (optimization in topDownTransformations) {
+                    element.accept(optimization)
+                }
+            }
+        }
+    }
+}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/Polycommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/Polycommands.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -25,11 +25,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
  * number, you can omit the separator between it and the preceeding
  * pair. It becomes 10,0-1,1.
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.Polycommands"),
-)
-class Polycommands : TopDownOptimization {
+class Polycommands : TopDownTransformation {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/Polycommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/Polycommands.kt
@@ -25,7 +25,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
  * number, you can omit the separator between it and the preceeding
  * pair. It becomes 10,0-1,1.
  */
-class Polycommands : TopDownTransformation {
+class Polycommands : TopDownTransformer {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.ContainerElement
@@ -11,11 +11,7 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 /**
  * Remove unnecessary groups
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.RemoveEmptyGroups"),
-)
-class RemoveEmptyGroups : BottomUpOptimization {
+class RemoveEmptyGroups : BottomUpTransformation {
     override fun visit(graphic: Graphic) {
         removeEmptyGroups(graphic)
     }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveEmptyGroups.kt
@@ -11,7 +11,7 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 /**
  * Remove unnecessary groups
  */
-class RemoveEmptyGroups : BottomUpTransformation {
+class RemoveEmptyGroups : BottomUpTransformer {
     override fun visit(graphic: Graphic) {
         removeEmptyGroups(graphic)
     }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -26,11 +26,7 @@ import kotlin.math.absoluteValue
 /**
  * Elide commands that don't contribute to the overall graphic
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.RemoveRedundantCommands"),
-)
-class RemoveRedundantCommands : TopDownOptimization {
+class RemoveRedundantCommands : TopDownTransformation {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveRedundantCommands.kt
@@ -26,7 +26,7 @@ import kotlin.math.absoluteValue
 /**
  * Elide commands that don't contribute to the overall graphic
  */
-class RemoveRedundantCommands : TopDownTransformation {
+class RemoveRedundantCommands : TopDownTransformer {
     override fun visit(graphic: Graphic) {}
 
     override fun visit(clipPath: ClipPath) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths.kt
@@ -7,7 +7,7 @@ import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.graphic.Group
 import com.jzbrooks.vgo.core.graphic.Path
 
-class RemoveTransparentPaths : TopDownTransformation {
+class RemoveTransparentPaths : TopDownTransformer {
     override fun visit(graphic: Graphic) = removeTransparentPaths(graphic)
 
     override fun visit(group: Group) = removeTransparentPaths(group)

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/RemoveTransparentPaths.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.ContainerElement
@@ -7,11 +7,7 @@ import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.graphic.Group
 import com.jzbrooks.vgo.core.graphic.Path
 
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.RemoveTransparentPaths"),
-)
-class RemoveTransparentPaths : TopDownOptimization {
+class RemoveTransparentPaths : TopDownTransformation {
     override fun visit(graphic: Graphic) = removeTransparentPaths(graphic)
 
     override fun visit(group: Group) = removeTransparentPaths(group)

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -21,13 +21,9 @@ import kotlin.math.sqrt
 /**
  * Convert curves into shorter commands where possible
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.SimplifyBezierCurveCommands"),
-)
 class SimplifyBezierCurveCommands(
     private val tolerance: Float,
-) : TopDownOptimization {
+) : TopDownTransformation {
     private var skipAnother = false
 
     override fun visit(graphic: Graphic) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommands.kt
@@ -23,7 +23,7 @@ import kotlin.math.sqrt
  */
 class SimplifyBezierCurveCommands(
     private val tolerance: Float,
-) : TopDownTransformation {
+) : TopDownTransformer {
     private var skipAnother = false
 
     override fun visit(graphic: Graphic) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyLineCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyLineCommands.kt
@@ -19,7 +19,7 @@ import kotlin.math.sign
  */
 class SimplifyLineCommands(
     private val tolerance: Float,
-) : TopDownTransformation {
+) : TopDownTransformer {
     lateinit var commands: MutableList<Command>
 
     override fun visit(graphic: Graphic) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyLineCommands.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyLineCommands.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ClipPath
 import com.jzbrooks.vgo.core.graphic.Extra
@@ -17,13 +17,9 @@ import kotlin.math.sign
 /**
  * Convert lines into shorter commands where possible
  */
-@Deprecated(
-    "Has been relocated to the transformation package",
-    replaceWith = ReplaceWith("com.jzbrooks.vgo.core.transformation.SimplifyLineCommands"),
-)
 class SimplifyLineCommands(
     private val tolerance: Float,
-) : TopDownOptimization {
+) : TopDownTransformation {
     lateinit var commands: MutableList<Command>
 
     override fun visit(graphic: Graphic) {}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TopDownTransformation.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TopDownTransformation.kt
@@ -2,4 +2,5 @@ package com.jzbrooks.vgo.core.transformation
 
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
 
+/** This transformation should be applied from the root [com.jzbrooks.vgo.core.graphic.Element] to the leaves */
 interface TopDownTransformation : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TopDownTransformation.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TopDownTransformation.kt
@@ -1,0 +1,5 @@
+package com.jzbrooks.vgo.core.transformation
+
+import com.jzbrooks.vgo.core.graphic.ElementVisitor
+
+interface TopDownTransformation : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TopDownTransformer.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TopDownTransformer.kt
@@ -3,4 +3,4 @@ package com.jzbrooks.vgo.core.transformation
 import com.jzbrooks.vgo.core.graphic.ElementVisitor
 
 /** This transformation should be applied from the root [com.jzbrooks.vgo.core.graphic.Element] to the leaves */
-interface TopDownTransformation : ElementVisitor
+interface TopDownTransformer : ElementVisitor

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TransformerSet.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TransformerSet.kt
@@ -4,7 +4,7 @@ import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.util.element.traverseBottomUp
 import com.jzbrooks.vgo.core.util.element.traverseTopDown
 
-abstract class Optimizer(
+abstract class TransformerSet(
     private val bottomUpTransformations: List<BottomUpTransformation>,
     private val topDownTransformations: List<TopDownTransformation>,
 ) {

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TransformerSet.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/transformation/TransformerSet.kt
@@ -5,21 +5,21 @@ import com.jzbrooks.vgo.core.util.element.traverseBottomUp
 import com.jzbrooks.vgo.core.util.element.traverseTopDown
 
 abstract class TransformerSet(
-    private val bottomUpTransformations: List<BottomUpTransformation>,
-    private val topDownTransformations: List<TopDownTransformation>,
+    private val bottomUpTransformers: List<BottomUpTransformer>,
+    private val topDownTransformers: List<TopDownTransformer>,
 ) {
     fun apply(graphic: Graphic) {
-        if (bottomUpTransformations.isNotEmpty()) {
+        if (bottomUpTransformers.isNotEmpty()) {
             traverseBottomUp(graphic) { element ->
-                for (optimization in bottomUpTransformations) {
+                for (optimization in bottomUpTransformers) {
                     element.accept(optimization)
                 }
             }
         }
 
-        if (topDownTransformations.isNotEmpty()) {
+        if (topDownTransformers.isNotEmpty()) {
             traverseTopDown(graphic) { element ->
-                for (optimization in topDownTransformations) {
+                for (optimization in topDownTransformers) {
                     element.accept(optimization)
                 }
             }

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/BakeTransformationsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/BakeTransformationsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.all
 import assertk.assertThat

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommandsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/BreakoutImplicitCommandsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.hasSize

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/CollapseGroupsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/CollapseGroupsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.containsExactly

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/CommandVariantTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/CommandVariantTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.hasSize
@@ -19,7 +19,7 @@ import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
 import com.jzbrooks.vgo.core.util.element.createPath
 import com.jzbrooks.vgo.core.util.math.Point
 import org.junit.jupiter.api.Test
-import com.jzbrooks.vgo.core.optimization.CommandVariant as CommandVariantOpt
+import com.jzbrooks.vgo.core.transformation.CommandVariant as CommandVariantOpt
 
 class CommandVariantTests {
     @Test

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcsTest.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/ConvertCurvesToArcsTest.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.hasSize

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/MergePathsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/MergePathsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.all
 import assertk.assertThat

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/RemoveEmptyGroupsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/RemoveEmptyGroupsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.hasSize

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/RemoveRedundantCommandsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/RemoveRedundantCommandsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.containsNone

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/RemoveTransparentPathsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/RemoveTransparentPathsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.hasSize

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommandsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyBezierCurveCommandsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.index

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyLineCommandsTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/transformation/SimplifyLineCommandsTests.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.core.optimization
+package com.jzbrooks.vgo.core.transformation
 
 import assertk.assertThat
 import assertk.assertions.containsOnly

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
@@ -6,16 +6,16 @@ import com.jzbrooks.vgo.core.transformation.CollapseGroups
 import com.jzbrooks.vgo.core.transformation.CommandVariant
 import com.jzbrooks.vgo.core.transformation.ConvertCurvesToArcs
 import com.jzbrooks.vgo.core.transformation.MergePaths
-import com.jzbrooks.vgo.core.transformation.Optimizer
 import com.jzbrooks.vgo.core.transformation.Polycommands
 import com.jzbrooks.vgo.core.transformation.RemoveEmptyGroups
 import com.jzbrooks.vgo.core.transformation.RemoveRedundantCommands
 import com.jzbrooks.vgo.core.transformation.RemoveTransparentPaths
 import com.jzbrooks.vgo.core.transformation.SimplifyBezierCurveCommands
 import com.jzbrooks.vgo.core.transformation.SimplifyLineCommands
+import com.jzbrooks.vgo.core.transformation.TransformerSet
 
 class SvgOptimizationRegistry :
-    Optimizer(
+    TransformerSet(
         bottomUpTransformations =
             listOf(
                 BakeTransformations(),

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
@@ -1,29 +1,29 @@
 package com.jzbrooks.vgo.svg
 
-import com.jzbrooks.vgo.core.optimization.BakeTransformations
-import com.jzbrooks.vgo.core.optimization.BreakoutImplicitCommands
-import com.jzbrooks.vgo.core.optimization.CollapseGroups
-import com.jzbrooks.vgo.core.optimization.CommandVariant
-import com.jzbrooks.vgo.core.optimization.ConvertCurvesToArcs
-import com.jzbrooks.vgo.core.optimization.MergePaths
-import com.jzbrooks.vgo.core.optimization.OptimizationRegistry
-import com.jzbrooks.vgo.core.optimization.Polycommands
-import com.jzbrooks.vgo.core.optimization.RemoveEmptyGroups
-import com.jzbrooks.vgo.core.optimization.RemoveRedundantCommands
-import com.jzbrooks.vgo.core.optimization.RemoveTransparentPaths
-import com.jzbrooks.vgo.core.optimization.SimplifyBezierCurveCommands
-import com.jzbrooks.vgo.core.optimization.SimplifyLineCommands
+import com.jzbrooks.vgo.core.transformation.BakeTransformations
+import com.jzbrooks.vgo.core.transformation.BreakoutImplicitCommands
+import com.jzbrooks.vgo.core.transformation.CollapseGroups
+import com.jzbrooks.vgo.core.transformation.CommandVariant
+import com.jzbrooks.vgo.core.transformation.ConvertCurvesToArcs
+import com.jzbrooks.vgo.core.transformation.MergePaths
+import com.jzbrooks.vgo.core.transformation.Optimizer
+import com.jzbrooks.vgo.core.transformation.Polycommands
+import com.jzbrooks.vgo.core.transformation.RemoveEmptyGroups
+import com.jzbrooks.vgo.core.transformation.RemoveRedundantCommands
+import com.jzbrooks.vgo.core.transformation.RemoveTransparentPaths
+import com.jzbrooks.vgo.core.transformation.SimplifyBezierCurveCommands
+import com.jzbrooks.vgo.core.transformation.SimplifyLineCommands
 
 class SvgOptimizationRegistry :
-    OptimizationRegistry(
-        bottomUpOptimizations =
+    Optimizer(
+        bottomUpTransformations =
             listOf(
                 BakeTransformations(),
                 CollapseGroups(),
                 RemoveEmptyGroups(),
                 MergePaths(MergePaths.Constraints.None),
             ),
-        topDownOptimizations =
+        topDownTransformations =
             listOf(
                 RemoveTransparentPaths(),
                 BreakoutImplicitCommands(),

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/svg/SvgOptimizationRegistry.kt
@@ -16,14 +16,14 @@ import com.jzbrooks.vgo.core.transformation.TransformerSet
 
 class SvgOptimizationRegistry :
     TransformerSet(
-        bottomUpTransformations =
+        bottomUpTransformers =
             listOf(
                 BakeTransformations(),
                 CollapseGroups(),
                 RemoveEmptyGroups(),
                 MergePaths(MergePaths.Constraints.None),
             ),
-        topDownTransformations =
+        topDownTransformers =
             listOf(
                 RemoveTransparentPaths(),
                 BreakoutImplicitCommands(),

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
@@ -16,7 +16,7 @@ import com.jzbrooks.vgo.core.transformation.TransformerSet
 
 class VectorDrawableOptimizationRegistry :
     TransformerSet(
-        bottomUpTransformations =
+        bottomUpTransformers =
             listOf(
                 BakeTransformations(),
                 CollapseGroups(),
@@ -24,7 +24,7 @@ class VectorDrawableOptimizationRegistry :
                 // https://cs.android.com/android/platform/superproject/main/+/2e48e15a8097916063eacc023044bc90bb93c73e:frameworks/base/libs/androidfw/StringPool.cpp;l=328
                 MergePaths(MergePaths.Constraints.PathLength(VectorDrawableCommandPrinter(3), (1 shl 15) - 1)),
             ),
-        topDownTransformations =
+        topDownTransformers =
             listOf(
                 RemoveTransparentPaths(),
                 BreakoutImplicitCommands(),

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
@@ -6,16 +6,16 @@ import com.jzbrooks.vgo.core.transformation.CollapseGroups
 import com.jzbrooks.vgo.core.transformation.CommandVariant
 import com.jzbrooks.vgo.core.transformation.ConvertCurvesToArcs
 import com.jzbrooks.vgo.core.transformation.MergePaths
-import com.jzbrooks.vgo.core.transformation.Optimizer
 import com.jzbrooks.vgo.core.transformation.Polycommands
 import com.jzbrooks.vgo.core.transformation.RemoveEmptyGroups
 import com.jzbrooks.vgo.core.transformation.RemoveRedundantCommands
 import com.jzbrooks.vgo.core.transformation.RemoveTransparentPaths
 import com.jzbrooks.vgo.core.transformation.SimplifyBezierCurveCommands
 import com.jzbrooks.vgo.core.transformation.SimplifyLineCommands
+import com.jzbrooks.vgo.core.transformation.TransformerSet
 
 class VectorDrawableOptimizationRegistry :
-    Optimizer(
+    TransformerSet(
         bottomUpTransformations =
             listOf(
                 BakeTransformations(),

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/vd/VectorDrawableOptimizationRegistry.kt
@@ -1,22 +1,22 @@
 package com.jzbrooks.vgo.vd
 
-import com.jzbrooks.vgo.core.optimization.BakeTransformations
-import com.jzbrooks.vgo.core.optimization.BreakoutImplicitCommands
-import com.jzbrooks.vgo.core.optimization.CollapseGroups
-import com.jzbrooks.vgo.core.optimization.CommandVariant
-import com.jzbrooks.vgo.core.optimization.ConvertCurvesToArcs
-import com.jzbrooks.vgo.core.optimization.MergePaths
-import com.jzbrooks.vgo.core.optimization.OptimizationRegistry
-import com.jzbrooks.vgo.core.optimization.Polycommands
-import com.jzbrooks.vgo.core.optimization.RemoveEmptyGroups
-import com.jzbrooks.vgo.core.optimization.RemoveRedundantCommands
-import com.jzbrooks.vgo.core.optimization.RemoveTransparentPaths
-import com.jzbrooks.vgo.core.optimization.SimplifyBezierCurveCommands
-import com.jzbrooks.vgo.core.optimization.SimplifyLineCommands
+import com.jzbrooks.vgo.core.transformation.BakeTransformations
+import com.jzbrooks.vgo.core.transformation.BreakoutImplicitCommands
+import com.jzbrooks.vgo.core.transformation.CollapseGroups
+import com.jzbrooks.vgo.core.transformation.CommandVariant
+import com.jzbrooks.vgo.core.transformation.ConvertCurvesToArcs
+import com.jzbrooks.vgo.core.transformation.MergePaths
+import com.jzbrooks.vgo.core.transformation.Optimizer
+import com.jzbrooks.vgo.core.transformation.Polycommands
+import com.jzbrooks.vgo.core.transformation.RemoveEmptyGroups
+import com.jzbrooks.vgo.core.transformation.RemoveRedundantCommands
+import com.jzbrooks.vgo.core.transformation.RemoveTransparentPaths
+import com.jzbrooks.vgo.core.transformation.SimplifyBezierCurveCommands
+import com.jzbrooks.vgo.core.transformation.SimplifyLineCommands
 
 class VectorDrawableOptimizationRegistry :
-    OptimizationRegistry(
-        bottomUpOptimizations =
+    Optimizer(
+        bottomUpTransformations =
             listOf(
                 BakeTransformations(),
                 CollapseGroups(),
@@ -24,7 +24,7 @@ class VectorDrawableOptimizationRegistry :
                 // https://cs.android.com/android/platform/superproject/main/+/2e48e15a8097916063eacc023044bc90bb93c73e:frameworks/base/libs/androidfw/StringPool.cpp;l=328
                 MergePaths(MergePaths.Constraints.PathLength(VectorDrawableCommandPrinter(3), (1 shl 15) - 1)),
             ),
-        topDownOptimizations =
+        topDownTransformations =
             listOf(
                 RemoveTransparentPaths(),
                 BreakoutImplicitCommands(),


### PR DESCRIPTION
Optimization doesn't really make a ton of sense for every class that implements the relevant interfaces. They're really transformations of the IR, so this change is a step toward reflecting that in package and class names.