### PR TITLE
Decouple kotlin compiler from plugin

### DIFF
--- a/vgo-cli/build.gradle.kts
+++ b/vgo-cli/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     implementation(project(":vgo"))
 
     implementation("com.android.tools:sdk-common:31.10.0")
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.20")
 
     r8("com.android.tools:r8:8.7.18")
 

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
@@ -62,7 +62,7 @@ Options:
   -s --stats         print statistics on processed files to standard out
   -v --version       print the version number
   --indent value     write files with value columns of indentation
-  --format value     write specified output format (svg, vd)
+  --format value     write specified output format (svg, vd, iv)
   --no-optimization  skip graphic optimization
             """.trimIndent()
 

--- a/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/OutputFormat.kt
+++ b/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/OutputFormat.kt
@@ -5,5 +5,6 @@ enum class OutputFormat(
 ) {
     SVG("svg"),
     VECTOR_DRAWABLE("vd"),
+    IMAGE_VECTOR("iv"),
     UNCHANGED("unchanged"),
 }

--- a/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/ShrinkVectorArtwork.kt
+++ b/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/ShrinkVectorArtwork.kt
@@ -3,6 +3,7 @@ package com.jzbrooks.vgo.plugin
 import com.jzbrooks.vgo.Vgo
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.getByType
 import java.io.File
@@ -23,6 +24,9 @@ open class ShrinkVectorArtwork : DefaultTask() {
     @get:Input
     val files: List<String> = (extension.inputs ?: defaultTree).files.map(File::getAbsolutePath)
 
+    @get:OutputFiles
+    val outputFiles: List<String> = (extension.outputs ?: extension.inputs)?.files.orEmpty().map(File::getAbsolutePath)
+
     @get:Input
     val showStatistics = extension.showStatistics
 
@@ -37,12 +41,19 @@ open class ShrinkVectorArtwork : DefaultTask() {
 
     @TaskAction
     fun shrink() {
+        logger.lifecycle("Extension outputs: ${extension.outputs?.files}")
+        logger.lifecycle("Outputs: $outputFiles")
+
+        for (file in extension.outputs?.files ?: emptyList()) {
+            file.mkdirs()
+        }
+
         val options =
             Vgo.Options(
                 printVersion = false,
                 printStats = showStatistics,
                 indent = indent.takeIf { it > 0 }?.toInt(),
-                output = emptyList(),
+                output = outputFiles,
                 format = outputFormat.cliName,
                 input = files,
                 noOptimization = noOptimization,

--- a/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/VgoPluginExtension.kt
+++ b/vgo-plugin/src/main/kotlin/com/jzbrooks/vgo/plugin/VgoPluginExtension.kt
@@ -4,7 +4,7 @@ import org.gradle.api.file.FileTree
 
 open class VgoPluginExtension {
     var inputs: FileTree? = null
-    var outputs: FileTree? = inputs
+    var outputs: FileTree? = null
     var showStatistics = true
     var format = OutputFormat.UNCHANGED
     var noOptimization = false

--- a/vgo/build.gradle.kts
+++ b/vgo/build.gradle.kts
@@ -17,9 +17,12 @@ kotlin.sourceSets
 dependencies {
     implementation(project(":vgo-core"))
 
+    // Provided by the android gradle plugin
     compileOnly("com.android.tools:sdk-common:31.10.0")
 
-    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.20")
+    // Provided by kotlin gradle plugin
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.20")
+
     implementation("com.squareup:kotlinpoet:2.1.0")
 
     testImplementation(platform("org.junit:junit-bom:5.12.2"))

--- a/vgo/build.gradle.kts
+++ b/vgo/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     testImplementation("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
+    testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.1.20")
+
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.28.1")
 }
 


### PR DESCRIPTION
After shipping https://github.com/jzbrooks/vgo/releases/tag/v3.2.0, builds that use the gradle plugin which also have the kotlin compiler on the build classpath started warning of duplication on the build classpath. So this removes the hard dependency for the kotlin compiler on the plugin (while keeping the dep on the CLI) and requires that consumers of the plugin who wish to use that functionality also have the kotlin compiler on their classpath.

- [x] Document the plugin requirement
- [x] Create issues to improve input/output handling
- [x] Is showStatistics broken for the plugin only for image vector?
- [x] Create issue to use file name for image vector property when converting to image vector (both files imaged below had a top level `vector` property of the same type, which is a compile error since they're in the same package).