### PR TITLE
Add IR dump option to cli

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Added
+- `--print-ir[=MODE]` to dump vgo intermediate representation. MODE is `auto` by default, which honors `NO_COLOR`
+`CLICOLOR_FORCE`, and `TERM` environment variables while also only using ANSI color escape sequences if the output
+is a terminal.
 
 ### Changed
 - `MergePaths` will merge opaque stroke, no fill paths regardless of overlap.

--- a/readme.md
+++ b/readme.md
@@ -68,13 +68,14 @@ vgo {
 > vgo [options] [file/directory]
 
 Options:
-  -h --help       print this message
-  -o --output     file or directory, if not provided the input will be overwritten
-  -s --stats      print statistics on processed files to standard out
-  -v --version    print the version number
-  --indent [value]  write files with value columns of indentation
-  --format [value]  output format (svg, vd, iv)
-  --no-optimiation  skip graphic optimization
+  -h --help          print this message
+  -o --output        file or directory, if not provided the input will be overwritten
+  -s --stats         print statistics on processed files to standard out
+  -v --version       print the version number
+  --indent [value]   write files with value columns of indentation
+  --format [value]   output format (svg, vd, iv)
+  --no-optimiation   skip graphic optimization
+  --print-ir[=MODE]  print IR tree and exit without writing (auto [default], color, plain; use = to pass mode)  
 ```
 
 > `java -jar vgo` for Windows

--- a/vgo-cli/build.gradle.kts
+++ b/vgo-cli/build.gradle.kts
@@ -114,6 +114,7 @@ val r8: Configuration = configurations.create("r8")
 
 dependencies {
     implementation(project(":vgo"))
+    implementation(project(":vgo-core"))
 
     implementation("com.android.tools:sdk-common:32.2.1")
     implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.0")

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/AnsiColorScheme.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/AnsiColorScheme.kt
@@ -1,0 +1,24 @@
+package com.jzbrooks.vgo.cli
+
+import com.jzbrooks.vgo.core.util.ir.IrColorScheme
+
+private const val ESC = ""
+private const val RESET = "$ESC[0m"
+
+object AnsiColorScheme : IrColorScheme {
+    override fun bold(s: String) = "$ESC[1m$s$RESET"
+
+    override fun cyan(s: String) = "$ESC[36m$s$RESET"
+
+    override fun green(s: String) = "$ESC[32m$s$RESET"
+
+    override fun yellow(s: String) = "$ESC[33m$s$RESET"
+
+    override fun dim(s: String) = "$ESC[2m$s$RESET"
+
+    override fun colorSwatch(
+        red: Int,
+        green: Int,
+        blue: Int,
+    ) = "$ESC[38;2;$red;$green;${blue}m■$RESET"
+}

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/ArgReader.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/ArgReader.kt
@@ -31,6 +31,29 @@ class ArgReader(
         return true
     }
 
+    fun readOptionWithDefault(
+        name: String,
+        default: String,
+    ): String? {
+        require(name.isNotBlank())
+
+        val names = name.split('|')
+        if (names.size > 1) {
+            return names.map { readOptionWithDefault(it, default) }.firstOrNull { it != null }
+        }
+
+        val prefix = optionPrefix(name) + "="
+        val eqIndex = args.indexOfFirst { it.startsWith(prefix) }
+        if (eqIndex != -1) {
+            return args.removeAt(eqIndex).removePrefix(prefix)
+        }
+
+        val index = args.indexOfFirst { isOptionArgument(name, it) }
+        if (index == -1) return null
+        args.removeAt(index)
+        return default
+    }
+
     fun readOption(name: String): String? {
         require(name.isNotBlank())
 
@@ -39,12 +62,18 @@ class ArgReader(
             return names.map(::readOption).firstOrNull { it != null }
         }
 
+        val prefix = optionPrefix(name) + "="
+        val eqIndex = args.indexOfFirst { it.startsWith(prefix) }
+        if (eqIndex != -1) {
+            return args.removeAt(eqIndex).removePrefix(prefix)
+        }
+
         val index = args.indexOfFirst { isOptionArgument(name, it) }
         if (index == -1) return null
 
         val value =
             args.getOrElse(index + 1) {
-                throw IllegalStateException("Missing value after ${if (name.length == 1) "-" else "--"}$name")
+                throw IllegalStateException("Missing value after ${optionPrefix(name)}")
             }
 
         args.removeAt(index)
@@ -72,14 +101,11 @@ class ArgReader(
     companion object {
         private fun isOption(name: String) = name.length >= 2 && name[0] == '-'
 
+        private fun optionPrefix(name: String) = if (name.length == 1) "-$name" else "--$name"
+
         private fun isOptionArgument(
             name: String,
             argument: String,
-        ): Boolean =
-            if (name.length == 1) {
-                "-$name" == argument
-            } else {
-                "--$name" == argument
-            }
+        ): Boolean = optionPrefix(name) == argument
     }
 }

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/ColorSupport.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/ColorSupport.kt
@@ -1,0 +1,30 @@
+package com.jzbrooks.vgo.cli
+
+internal fun colorEnabled(
+    env: (String) -> String? = System::getenv,
+    stdoutIsTerminal: () -> Boolean = ::stdoutIsTerminal,
+): Boolean {
+    if (!env("NO_COLOR").isNullOrEmpty()) return false
+    val force = env("CLICOLOR_FORCE")
+    if (!force.isNullOrEmpty() && force != "0") return true
+    if (env("TERM") == "dumb") return false
+    return stdoutIsTerminal()
+}
+
+internal fun stdoutIsTerminal(): Boolean {
+    // JDK 25 Release Notes, JDK-8308591: JLine as the default Console provider
+
+    // - The null guard matters most on ≤ 21 and 25+, where a redirected process simply has no console.
+    val console = System.console() ?: return false
+
+    // The isTerminal call matters most on 22–24, where a console object
+    // exists even when piped — the null check alone would spray ANSI into
+    // redirected output there. And on 25+ it's still not dead code: the
+    // JLine provider remains opt-in-able, so "console exists, but it's
+    // not a terminal" is still a reachable state.
+    return if (Runtime.version().feature() >= 22) {
+        java.io.Console::class.java.getMethod("isTerminal").invoke(console) as Boolean
+    } else {
+        true
+    }
+}

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
@@ -15,6 +15,7 @@ class CommandLineInterface {
 
         val printVersion = argReader.readFlag("version|v")
         val printStats = argReader.readFlag("stats|s")
+        val printIrMode = argReader.readOptionWithDefault("print-ir", "color")
         val indent = argReader.readOption("indent")?.toIntOrNull()
 
         val outputs =
@@ -46,6 +47,7 @@ class CommandLineInterface {
                 format = format,
                 noOptimization = noOptimization,
                 input = inputs,
+                onGraphicReady = printIrMode?.let { mode -> IrPrinter(System.out, mode != "plain")::visit },
             )
 
         return Vgo(options).run()
@@ -64,6 +66,7 @@ Options:
   --indent value     write files with value columns of indentation
   --format value     write specified output format (svg, vd, iv)
   --no-optimization  skip graphic optimization
+  --print-ir[=MODE]  print IR tree after optimization and exit without writing (color [default], plain; use = to pass mode)
             """.trimIndent()
 
         @JvmStatic

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
@@ -89,7 +89,7 @@ Options:
   --indent value     write files with value columns of indentation
   --format value     write specified output format (svg, vd, iv)
   --no-optimization  skip graphic optimization
-  --print-ir[=MODE]  print IR tree after optimization and exit without writing (auto [default], color, plain; use = to pass mode)
+  --print-ir[=MODE]  print IR tree and exit without writing (auto [default], color, plain; use = to pass mode)
             """.trimIndent()
 
         @JvmStatic

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
@@ -1,6 +1,7 @@
 package com.jzbrooks.vgo.cli
 
 import com.jzbrooks.vgo.Vgo
+import com.jzbrooks.vgo.core.util.ir.PlainColorScheme
 import kotlin.system.exitProcess
 
 class CommandLineInterface {
@@ -50,11 +51,11 @@ class CommandLineInterface {
                 dumpIr =
                     when (printIrMode) {
                         "plain" -> {
-                            Vgo.Options.IrDumpMode.Plain
+                            Vgo.Options.IrDumpOptions(PlainColorScheme)
                         }
 
                         "color" -> {
-                            Vgo.Options.IrDumpMode.Color
+                            Vgo.Options.IrDumpOptions(AnsiColorScheme)
                         }
 
                         null -> {

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
@@ -16,7 +16,7 @@ class CommandLineInterface {
 
         val printVersion = argReader.readFlag("version|v")
         val printStats = argReader.readFlag("stats|s")
-        val printIrMode = argReader.readOptionWithDefault("print-ir", "color")
+        val printIrMode = argReader.readOptionWithDefault("print-ir", "auto")
         val indent = argReader.readOption("indent")?.toIntOrNull()
 
         val outputs =
@@ -50,6 +50,10 @@ class CommandLineInterface {
                 input = inputs,
                 dumpIr =
                     when (printIrMode) {
+                        "auto" -> {
+                            Vgo.Options.IrDumpOptions(if (colorEnabled()) AnsiColorScheme else PlainColorScheme)
+                        }
+
                         "plain" -> {
                             Vgo.Options.IrDumpOptions(PlainColorScheme)
                         }
@@ -85,7 +89,7 @@ Options:
   --indent value     write files with value columns of indentation
   --format value     write specified output format (svg, vd, iv)
   --no-optimization  skip graphic optimization
-  --print-ir[=MODE]  print IR tree after optimization and exit without writing (color [default], plain; use = to pass mode)
+  --print-ir[=MODE]  print IR tree after optimization and exit without writing (auto [default], color, plain; use = to pass mode)
             """.trimIndent()
 
         @JvmStatic

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/CommandLineInterface.kt
@@ -47,7 +47,25 @@ class CommandLineInterface {
                 format = format,
                 noOptimization = noOptimization,
                 input = inputs,
-                onGraphicReady = printIrMode?.let { mode -> IrPrinter(System.out, mode != "plain")::visit },
+                dumpIr =
+                    when (printIrMode) {
+                        "plain" -> {
+                            Vgo.Options.IrDumpMode.Plain
+                        }
+
+                        "color" -> {
+                            Vgo.Options.IrDumpMode.Color
+                        }
+
+                        null -> {
+                            null
+                        }
+
+                        else -> {
+                            System.err.println("Warning: unsupported ir dump mode $printIrMode")
+                            null
+                        }
+                    },
             )
 
         return Vgo(options).run()

--- a/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/IrPrinter.kt
+++ b/vgo-cli/src/main/kotlin/com/jzbrooks/vgo/cli/IrPrinter.kt
@@ -1,0 +1,291 @@
+package com.jzbrooks.vgo.cli
+
+import com.jzbrooks.vgo.core.Brush
+import com.jzbrooks.vgo.core.Color
+import com.jzbrooks.vgo.core.Colors
+import com.jzbrooks.vgo.core.HexFormat
+import com.jzbrooks.vgo.core.LinearGradient
+import com.jzbrooks.vgo.core.RadialGradient
+import com.jzbrooks.vgo.core.SweepGradient
+import com.jzbrooks.vgo.core.graphic.Circle
+import com.jzbrooks.vgo.core.graphic.ClipPath
+import com.jzbrooks.vgo.core.graphic.Element
+import com.jzbrooks.vgo.core.graphic.ElementVisitor
+import com.jzbrooks.vgo.core.graphic.Ellipse
+import com.jzbrooks.vgo.core.graphic.Extra
+import com.jzbrooks.vgo.core.graphic.Graphic
+import com.jzbrooks.vgo.core.graphic.Group
+import com.jzbrooks.vgo.core.graphic.Line
+import com.jzbrooks.vgo.core.graphic.Path
+import com.jzbrooks.vgo.core.graphic.Polygon
+import com.jzbrooks.vgo.core.graphic.Polyline
+import com.jzbrooks.vgo.core.graphic.Rect
+import com.jzbrooks.vgo.core.graphic.Shape
+import com.jzbrooks.vgo.core.graphic.command.ClosePath
+import com.jzbrooks.vgo.core.graphic.command.Command
+import com.jzbrooks.vgo.core.graphic.command.CommandVariant
+import com.jzbrooks.vgo.core.graphic.command.CubicBezierCurve
+import com.jzbrooks.vgo.core.graphic.command.EllipticalArcCurve
+import com.jzbrooks.vgo.core.graphic.command.HorizontalLineTo
+import com.jzbrooks.vgo.core.graphic.command.LineTo
+import com.jzbrooks.vgo.core.graphic.command.MoveTo
+import com.jzbrooks.vgo.core.graphic.command.QuadraticBezierCurve
+import com.jzbrooks.vgo.core.graphic.command.SmoothCubicBezierCurve
+import com.jzbrooks.vgo.core.graphic.command.SmoothQuadraticBezierCurve
+import com.jzbrooks.vgo.core.graphic.command.VerticalLineTo
+import com.jzbrooks.vgo.core.util.math.Matrix3
+import com.jzbrooks.vgo.core.util.math.Point
+import java.io.PrintStream
+
+private const val ESC = ""
+private const val RESET = "$ESC[0m"
+
+class IrPrinter(
+    private val out: PrintStream = System.out,
+    private val useColor: Boolean = true,
+) : ElementVisitor {
+    private val prefixStack = ArrayDeque<String>()
+
+    private fun prefix() = prefixStack.joinToString("")
+
+    private fun renderChildren(items: List<() -> Unit>) {
+        items.forEachIndexed { i, render ->
+            val isLast = i == items.lastIndex
+            out.print(dim(prefix() + if (isLast) "└── " else "├── "))
+            prefixStack.add(if (isLast) "    " else "│   ")
+            render()
+            prefixStack.removeLast()
+        }
+    }
+
+    private fun renderElementChildren(elements: List<Element>) {
+        renderChildren(elements.map { el -> { el.accept(this) } })
+    }
+
+    override fun visit(graphic: Graphic) {
+        val label =
+            buildString {
+                append(bold(graphic::class.simpleName ?: "Graphic"))
+                graphic.id?.let { append(" " + cyan("[$it]")) }
+                val vw = graphic.foreign["android:viewportWidth"]
+                val vh = graphic.foreign["android:viewportHeight"]
+                if (vw != null && vh != null) {
+                    append(dim(" (${vw}x$vh)"))
+                } else {
+                    val viewBox = graphic.foreign["viewBox"]
+                    if (viewBox != null) append(dim(" viewBox=$viewBox"))
+                }
+            }
+        out.println(label)
+        renderElementChildren(graphic.elements)
+    }
+
+    override fun visit(group: Group) {
+        val label =
+            buildString {
+                append(bold("Group"))
+                group.id?.let { append(" " + cyan("[$it]")) }
+                if (group.transform != Matrix3.IDENTITY) append(dim(" transform=..."))
+                if (group.clipPaths.isNotEmpty()) append(dim(" ${group.clipPaths.size} clip(s)"))
+            }
+        out.println(label)
+
+        val clipPathItems: List<() -> Unit> = group.clipPaths.map { cp -> { renderClipPath(cp) } }
+        val elementItems: List<() -> Unit> = group.elements.map { el -> { el.accept(this) } }
+        renderChildren(clipPathItems + elementItems)
+    }
+
+    override fun visit(path: Path) {
+        val label =
+            buildString {
+                append(bold("Path"))
+                path.id?.let { append(" " + cyan("[$it]")) }
+                append(" fill=").append(formatBrush(path.fill))
+                if (path.stroke != Colors.TRANSPARENT) {
+                    append(" stroke=").append(formatBrush(path.stroke))
+                    append(" sw=").append(formatFloat(path.strokeWidth))
+                }
+                append(dim(" (${path.commands.size} cmds)"))
+            }
+        out.println(label)
+        renderChildren(path.commands.map { cmd -> { out.println(formatCommand(cmd)) } })
+    }
+
+    override fun visit(extra: Extra) {
+        val label =
+            buildString {
+                append(bold("Extra"))
+                extra.id?.let { append(" " + cyan("[$it]")) }
+                append(dim(" <${extra.name}>"))
+                if (extra.elements.isNotEmpty()) append(dim(" (${extra.elements.size})"))
+            }
+        out.println(label)
+        if (extra.elements.isNotEmpty()) renderElementChildren(extra.elements)
+    }
+
+    override fun visit(shape: Shape) {
+        val label =
+            buildString {
+                append(bold(shape::class.simpleName ?: "Shape"))
+                shape.id?.let { append(" " + cyan("[$it]")) }
+                append(" fill=").append(formatBrush(shape.fill))
+                if (shape.stroke != Colors.TRANSPARENT) {
+                    append(" stroke=").append(formatBrush(shape.stroke))
+                }
+                when (shape) {
+                    is Circle -> {
+                        val cx = formatFloat(shape.cx)
+                        val cy = formatFloat(shape.cy)
+                        val r = formatFloat(shape.r)
+                        append(dim(" cx=$cx cy=$cy r=$r"))
+                    }
+
+                    is Ellipse -> {
+                        val cx = formatFloat(shape.cx)
+                        val cy = formatFloat(shape.cy)
+                        val rx = formatFloat(shape.rx)
+                        val ry = formatFloat(shape.ry)
+                        append(dim(" cx=$cx cy=$cy rx=$rx ry=$ry"))
+                    }
+
+                    is Rect -> {
+                        val x = formatFloat(shape.x)
+                        val y = formatFloat(shape.y)
+                        val w = formatFloat(shape.width)
+                        val h = formatFloat(shape.height)
+                        append(dim(" x=$x y=$y w=$w h=$h"))
+                    }
+
+                    is Line -> {
+                        val x1 = formatFloat(shape.x1)
+                        val y1 = formatFloat(shape.y1)
+                        val x2 = formatFloat(shape.x2)
+                        val y2 = formatFloat(shape.y2)
+                        append(dim(" ($x1,$y1)->($x2,$y2)"))
+                    }
+
+                    is Polyline -> {
+                        append(dim(" (${shape.points.size} pts)"))
+                    }
+
+                    is Polygon -> {
+                        append(dim(" (${shape.points.size} pts)"))
+                    }
+                }
+            }
+        out.println(label)
+    }
+
+    private fun renderClipPath(cp: ClipPath) {
+        val label =
+            buildString {
+                append(bold("ClipPath"))
+                cp.id?.let { append(" " + cyan("[$it]")) }
+                append(dim(" (${cp.regions.size})"))
+            }
+        out.println(label)
+        renderChildren(cp.regions.map { path -> { path.accept(this) } })
+    }
+
+    private fun formatCommand(cmd: Command): String =
+        when (cmd) {
+            is ClosePath -> {
+                green("Z")
+            }
+
+            is MoveTo -> {
+                letter(cmd.variant, "M", "m") + " " + cmd.parameters.joinToString(" ") { formatPoint(it) }
+            }
+
+            is LineTo -> {
+                letter(cmd.variant, "L", "l") + " " + cmd.parameters.joinToString(" ") { formatPoint(it) }
+            }
+
+            is HorizontalLineTo -> {
+                letter(cmd.variant, "H", "h") + " " + cmd.parameters.joinToString(" ") { formatFloat(it) }
+            }
+
+            is VerticalLineTo -> {
+                letter(cmd.variant, "V", "v") + " " + cmd.parameters.joinToString(" ") { formatFloat(it) }
+            }
+
+            is CubicBezierCurve -> {
+                letter(cmd.variant, "C", "c") + " " +
+                    cmd.parameters.joinToString(" ") { p ->
+                        "${formatPoint(p.startControl)} ${formatPoint(p.endControl)} ${formatPoint(p.end)}"
+                    }
+            }
+
+            is SmoothCubicBezierCurve -> {
+                letter(cmd.variant, "S", "s") + " " +
+                    cmd.parameters.joinToString(" ") { p ->
+                        "${formatPoint(p.endControl)} ${formatPoint(p.end)}"
+                    }
+            }
+
+            is QuadraticBezierCurve -> {
+                letter(cmd.variant, "Q", "q") + " " +
+                    cmd.parameters.joinToString(" ") { p ->
+                        "${formatPoint(p.control)} ${formatPoint(p.end)}"
+                    }
+            }
+
+            is SmoothQuadraticBezierCurve -> {
+                letter(cmd.variant, "T", "t") + " " + cmd.parameters.joinToString(" ") { formatPoint(it) }
+            }
+
+            is EllipticalArcCurve -> {
+                letter(cmd.variant, "A", "a") + " " +
+                    cmd.parameters.joinToString(" ") { p ->
+                        val arc = if (p.arc == EllipticalArcCurve.ArcFlag.LARGE) 1 else 0
+                        val sweep = if (p.sweep == EllipticalArcCurve.SweepFlag.CLOCKWISE) 1 else 0
+                        "${formatFloat(p.radiusX)},${formatFloat(p.radiusY)} ${formatFloat(p.angle)} $arc,$sweep ${formatPoint(p.end)}"
+                    }
+            }
+        }
+
+    private fun letter(
+        variant: CommandVariant,
+        abs: String,
+        rel: String,
+    ): String = green(if (variant == CommandVariant.ABSOLUTE) abs else rel)
+
+    private fun formatBrush(brush: Brush): String =
+        when (brush) {
+            is Color -> {
+                val hex = brush.toHexString(HexFormat.ARGB)
+                if (useColor) {
+                    val swatch = "$ESC[38;2;${brush.red.toInt()};${brush.green.toInt()};${brush.blue.toInt()}m■$RESET"
+                    "$swatch ${yellow(hex)}"
+                } else {
+                    hex
+                }
+            }
+
+            is LinearGradient -> {
+                dim("linear-gradient(${brush.stops.size} stops)")
+            }
+
+            is RadialGradient -> {
+                dim("radial-gradient(${brush.stops.size} stops)")
+            }
+
+            is SweepGradient -> {
+                dim("sweep-gradient(${brush.stops.size} stops)")
+            }
+        }
+
+    private fun formatPoint(p: Point): String = "${formatFloat(p.x)},${formatFloat(p.y)}"
+
+    private fun formatFloat(f: Float): String = if (f % 1f == 0f) f.toInt().toString() else f.toString()
+
+    private fun bold(s: String) = if (useColor) "$ESC[1m$s$RESET" else s
+
+    private fun cyan(s: String) = if (useColor) "$ESC[36m$s$RESET" else s
+
+    private fun green(s: String) = if (useColor) "$ESC[32m$s$RESET" else s
+
+    private fun yellow(s: String) = if (useColor) "$ESC[33m$s$RESET" else s
+
+    private fun dim(s: String) = if (useColor) "$ESC[2m$s$RESET" else s
+}

--- a/vgo-cli/src/test/kotlin/com/jzbrooks/vgo/cli/ColorSupportTests.kt
+++ b/vgo-cli/src/test/kotlin/com/jzbrooks/vgo/cli/ColorSupportTests.kt
@@ -1,0 +1,86 @@
+package com.jzbrooks.vgo.cli
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.jupiter.api.Test
+
+class ColorSupportTests {
+    @Test
+    fun `color is enabled for a terminal`() {
+        val enabled = colorEnabled(env = { null }, stdoutIsTerminal = { true })
+        assertThat(enabled).isTrue()
+    }
+
+    @Test
+    fun `color is disabled when stdout is not a terminal`() {
+        val enabled = colorEnabled(env = { null }, stdoutIsTerminal = { false })
+        assertThat(enabled).isFalse()
+    }
+
+    @Test
+    fun `no_color disables color for a terminal`() {
+        val enabled =
+            colorEnabled(
+                env = { if (it == "NO_COLOR") "1" else null },
+                stdoutIsTerminal = { true },
+            )
+        assertThat(enabled).isFalse()
+    }
+
+    @Test
+    fun `no_color takes precedence over clicolor_force`() {
+        val enabled =
+            colorEnabled(
+                env = {
+                    when (it) {
+                        "NO_COLOR" -> "1"
+                        "CLICOLOR_FORCE" -> "1"
+                        else -> null
+                    }
+                },
+                stdoutIsTerminal = { true },
+            )
+        assertThat(enabled).isFalse()
+    }
+
+    @Test
+    fun `empty no_color does not disable color`() {
+        val enabled =
+            colorEnabled(
+                env = { if (it == "NO_COLOR") "" else null },
+                stdoutIsTerminal = { true },
+            )
+        assertThat(enabled).isTrue()
+    }
+
+    @Test
+    fun `clicolor_force enables color when stdout is not a terminal`() {
+        val enabled =
+            colorEnabled(
+                env = { if (it == "CLICOLOR_FORCE") "1" else null },
+                stdoutIsTerminal = { false },
+            )
+        assertThat(enabled).isTrue()
+    }
+
+    @Test
+    fun `zero clicolor_force does not force color`() {
+        val enabled =
+            colorEnabled(
+                env = { if (it == "CLICOLOR_FORCE") "0" else null },
+                stdoutIsTerminal = { false },
+            )
+        assertThat(enabled).isFalse()
+    }
+
+    @Test
+    fun `dumb terminal disables color`() {
+        val enabled =
+            colorEnabled(
+                env = { if (it == "TERM") "dumb" else null },
+                stdoutIsTerminal = { true },
+            )
+        assertThat(enabled).isFalse()
+    }
+}

--- a/vgo-cli/src/test/kotlin/com/jzbrooks/vgo/cli/CommandLineInterfaceTests.kt
+++ b/vgo-cli/src/test/kotlin/com/jzbrooks/vgo/cli/CommandLineInterfaceTests.kt
@@ -20,16 +20,26 @@ class CommandLineInterfaceTests {
     private val avocadoExampleRelativePath = Paths.get("src/test/resources/avocado_example.xml").toString()
     private val heartExampleRelativePath = Paths.get("src/test/resources/simple_heart.xml").toString()
     private lateinit var systemOutput: ByteArrayOutputStream
+    private lateinit var systemError: ByteArrayOutputStream
+    private lateinit var originalOut: PrintStream
+    private lateinit var originalErr: PrintStream
 
     @BeforeEach
     fun redirect() {
+        originalOut = System.out
+        originalErr = System.err
         systemOutput = ByteArrayOutputStream()
+        systemError = ByteArrayOutputStream()
         System.setOut(PrintStream(systemOutput))
+        System.setErr(PrintStream(systemError))
     }
 
     @AfterEach
     fun cleanup() {
+        System.setOut(originalOut)
+        System.setErr(originalErr)
         systemOutput.close()
+        systemError.close()
     }
 
     @Test
@@ -194,6 +204,47 @@ class CommandLineInterfaceTests {
         val output = File("build/integrationTest/no-optimization-test.svg").readText()
         assertThat(output).startsWith("<svg")
         assertThat(output).hasLineCount(42)
+    }
+
+    @Test
+    fun `print-ir default mode produces ir output`() {
+        val arguments = arrayOf(heartExampleRelativePath, "--print-ir")
+        val exitCode = CommandLineInterface().run(arguments)
+        assertThat(exitCode).isEqualTo(0)
+        assertThat(systemOutput.toString()).contains("Path")
+    }
+
+    @Test
+    fun `print-ir plain mode produces no ansi escape codes`() {
+        val arguments = arrayOf(heartExampleRelativePath, "--print-ir=plain")
+        val exitCode = CommandLineInterface().run(arguments)
+        assertThat(exitCode).isEqualTo(0)
+        val esc = Char(0x1B).toString()
+        assertThat(systemOutput.toString()).doesNotContain(esc)
+    }
+
+    @Test
+    fun `print-ir color mode produces ansi escape codes`() {
+        val arguments = arrayOf(heartExampleRelativePath, "--print-ir=color")
+        val exitCode = CommandLineInterface().run(arguments)
+        assertThat(exitCode).isEqualTo(0)
+        val esc = Char(0x1B).toString()
+        assertThat(systemOutput.toString()).contains(esc)
+    }
+
+    @Test
+    fun `print-ir unknown mode warns and skips ir output`() {
+        val arguments =
+            arrayOf(
+                heartExampleRelativePath,
+                "-o",
+                "build/integrationTest/print-ir-unknown.xml",
+                "--print-ir=unknown",
+            )
+        val exitCode = CommandLineInterface().run(arguments)
+        assertThat(exitCode).isEqualTo(0)
+        assertThat(systemError.toString()).contains("unsupported ir dump mode")
+        assertThat(systemOutput.toString()).doesNotContain("Path")
     }
 
     companion object {

--- a/vgo-cli/src/test/kotlin/com/jzbrooks/vgo/cli/CommandLineInterfaceTests.kt
+++ b/vgo-cli/src/test/kotlin/com/jzbrooks/vgo/cli/CommandLineInterfaceTests.kt
@@ -233,6 +233,16 @@ class CommandLineInterfaceTests {
     }
 
     @Test
+    fun `print-ir auto mode produces plain output when stdout is not a terminal`() {
+        val arguments = arrayOf(heartExampleRelativePath, "--print-ir=auto")
+        val exitCode = CommandLineInterface().run(arguments)
+        assertThat(exitCode).isEqualTo(0)
+        val esc = Char(0x1B).toString()
+        assertThat(systemOutput.toString()).contains("Path")
+        assertThat(systemOutput.toString()).doesNotContain(esc)
+    }
+
+    @Test
     fun `print-ir unknown mode warns and skips ir output`() {
         val arguments =
             arrayOf(

--- a/vgo-core/api/vgo-core.api
+++ b/vgo-core/api/vgo-core.api
@@ -1000,6 +1000,46 @@ public final class com/jzbrooks/vgo/core/util/element/TraverseKt {
 	public static final fun traverseTopDown (Lcom/jzbrooks/vgo/core/graphic/Element;Lkotlin/jvm/functions/Function1;)Lcom/jzbrooks/vgo/core/graphic/Element;
 }
 
+public final class com/jzbrooks/vgo/core/util/ir/DebuggingKt {
+	public static final fun asIr (Lcom/jzbrooks/vgo/core/graphic/Graphic;)Ljava/lang/String;
+}
+
+public abstract interface class com/jzbrooks/vgo/core/util/ir/IrColorScheme {
+	public abstract fun bold (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public abstract fun colorSwatch (III)Ljava/lang/CharSequence;
+	public abstract fun cyan (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public abstract fun dim (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public abstract fun green (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public abstract fun yellow (Ljava/lang/String;)Ljava/lang/CharSequence;
+}
+
+public final class com/jzbrooks/vgo/core/util/ir/IrPrinter : com/jzbrooks/vgo/core/graphic/ElementVisitor {
+	public fun <init> ()V
+	public fun <init> (Ljava/io/PrintStream;Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;)V
+	public synthetic fun <init> (Ljava/io/PrintStream;Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Extra;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Graphic;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Group;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Path;)V
+	public fun visit (Lcom/jzbrooks/vgo/core/graphic/Shape;)V
+}
+
+public final class com/jzbrooks/vgo/core/util/ir/PlainColorScheme : com/jzbrooks/vgo/core/util/ir/IrColorScheme {
+	public static final field INSTANCE Lcom/jzbrooks/vgo/core/util/ir/PlainColorScheme;
+	public synthetic fun bold (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public fun bold (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun colorSwatch (III)Ljava/lang/CharSequence;
+	public fun colorSwatch (III)Ljava/lang/String;
+	public synthetic fun cyan (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public fun cyan (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun dim (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public fun dim (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun green (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public fun green (Ljava/lang/String;)Ljava/lang/String;
+	public synthetic fun yellow (Ljava/lang/String;)Ljava/lang/CharSequence;
+	public fun yellow (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class com/jzbrooks/vgo/core/util/math/CenterParameterization {
 	public fun <init> (Lcom/jzbrooks/vgo/core/util/math/Point;FFD)V
 	public final fun component1 ()Lcom/jzbrooks/vgo/core/util/math/Point;

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/Debugging.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/Debugging.kt
@@ -1,0 +1,19 @@
+package com.jzbrooks.vgo.core.util.ir
+
+import com.jzbrooks.vgo.core.graphic.Graphic
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+
+/**
+ * Graphic debugging that dumps IR into a string.
+ * Useful for debugging.
+ *
+ * Not intended for application use.
+ */
+fun Graphic.asIr(): String {
+    val baos = ByteArrayOutputStream()
+    val ps = PrintStream(baos, true, StandardCharsets.UTF_8)
+    IrPrinter(ps, false).visit(this)
+    return baos.toString(StandardCharsets.UTF_8)
+}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/Debugging.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/Debugging.kt
@@ -14,6 +14,6 @@ import java.nio.charset.StandardCharsets
 fun Graphic.asIr(): String {
     val baos = ByteArrayOutputStream()
     val ps = PrintStream(baos, true, StandardCharsets.UTF_8)
-    IrPrinter(ps, false).visit(this)
+    IrPrinter(ps).visit(this)
     return baos.toString(StandardCharsets.UTF_8)
 }

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/IrColorScheme.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/IrColorScheme.kt
@@ -1,0 +1,38 @@
+package com.jzbrooks.vgo.core.util.ir
+
+interface IrColorScheme {
+    fun bold(s: String): CharSequence
+
+    fun cyan(s: String): CharSequence
+
+    fun green(s: String): CharSequence
+
+    fun yellow(s: String): CharSequence
+
+    fun dim(s: String): CharSequence
+
+    /** Returns an ANSI swatch prefix for the given RGB color, or empty string for no swatch. */
+    fun colorSwatch(
+        red: Int,
+        green: Int,
+        blue: Int,
+    ): CharSequence
+}
+
+object PlainColorScheme : IrColorScheme {
+    override fun bold(s: String) = s
+
+    override fun cyan(s: String) = s
+
+    override fun green(s: String) = s
+
+    override fun yellow(s: String) = s
+
+    override fun dim(s: String) = s
+
+    override fun colorSwatch(
+        red: Int,
+        green: Int,
+        blue: Int,
+    ) = ""
+}

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinter.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinter.kt
@@ -1,4 +1,4 @@
-package com.jzbrooks.vgo.cli
+package com.jzbrooks.vgo.core.util.ir
 
 import com.jzbrooks.vgo.core.Brush
 import com.jzbrooks.vgo.core.Color

--- a/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinter.kt
+++ b/vgo-core/src/main/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinter.kt
@@ -37,12 +37,9 @@ import com.jzbrooks.vgo.core.util.math.Matrix3
 import com.jzbrooks.vgo.core.util.math.Point
 import java.io.PrintStream
 
-private const val ESC = ""
-private const val RESET = "$ESC[0m"
-
 class IrPrinter(
     private val out: PrintStream = System.out,
-    private val useColor: Boolean = true,
+    private val colorScheme: IrColorScheme = PlainColorScheme,
 ) : ElementVisitor {
     private val prefixStack = ArrayDeque<String>()
 
@@ -51,7 +48,7 @@ class IrPrinter(
     private fun renderChildren(items: List<() -> Unit>) {
         items.forEachIndexed { i, render ->
             val isLast = i == items.lastIndex
-            out.print(dim(prefix() + if (isLast) "└── " else "├── "))
+            out.print(colorScheme.dim(prefix() + if (isLast) "└── " else "├── "))
             prefixStack.add(if (isLast) "    " else "│   ")
             render()
             prefixStack.removeLast()
@@ -65,15 +62,15 @@ class IrPrinter(
     override fun visit(graphic: Graphic) {
         val label =
             buildString {
-                append(bold(graphic::class.simpleName ?: "Graphic"))
-                graphic.id?.let { append(" " + cyan("[$it]")) }
+                append(colorScheme.bold(graphic::class.simpleName ?: "Graphic"))
+                graphic.id?.let { append(" " + colorScheme.cyan("[$it]")) }
                 val vw = graphic.foreign["android:viewportWidth"]
                 val vh = graphic.foreign["android:viewportHeight"]
                 if (vw != null && vh != null) {
-                    append(dim(" (${vw}x$vh)"))
+                    append(colorScheme.dim(" (${vw}x$vh)"))
                 } else {
                     val viewBox = graphic.foreign["viewBox"]
-                    if (viewBox != null) append(dim(" viewBox=$viewBox"))
+                    if (viewBox != null) append(colorScheme.dim(" viewBox=$viewBox"))
                 }
             }
         out.println(label)
@@ -83,10 +80,10 @@ class IrPrinter(
     override fun visit(group: Group) {
         val label =
             buildString {
-                append(bold("Group"))
-                group.id?.let { append(" " + cyan("[$it]")) }
-                if (group.transform != Matrix3.IDENTITY) append(dim(" transform=..."))
-                if (group.clipPaths.isNotEmpty()) append(dim(" ${group.clipPaths.size} clip(s)"))
+                append(colorScheme.bold("Group"))
+                group.id?.let { append(" " + colorScheme.cyan("[$it]")) }
+                if (group.transform != Matrix3.IDENTITY) append(colorScheme.dim(" transform=..."))
+                if (group.clipPaths.isNotEmpty()) append(colorScheme.dim(" ${group.clipPaths.size} clip(s)"))
             }
         out.println(label)
 
@@ -98,14 +95,14 @@ class IrPrinter(
     override fun visit(path: Path) {
         val label =
             buildString {
-                append(bold("Path"))
-                path.id?.let { append(" " + cyan("[$it]")) }
+                append(colorScheme.bold("Path"))
+                path.id?.let { append(" " + colorScheme.cyan("[$it]")) }
                 append(" fill=").append(formatBrush(path.fill))
                 if (path.stroke != Colors.TRANSPARENT) {
                     append(" stroke=").append(formatBrush(path.stroke))
                     append(" sw=").append(formatFloat(path.strokeWidth))
                 }
-                append(dim(" (${path.commands.size} cmds)"))
+                append(colorScheme.dim(" (${path.commands.size} cmds)"))
             }
         out.println(label)
         renderChildren(path.commands.map { cmd -> { out.println(formatCommand(cmd)) } })
@@ -114,10 +111,10 @@ class IrPrinter(
     override fun visit(extra: Extra) {
         val label =
             buildString {
-                append(bold("Extra"))
-                extra.id?.let { append(" " + cyan("[$it]")) }
-                append(dim(" <${extra.name}>"))
-                if (extra.elements.isNotEmpty()) append(dim(" (${extra.elements.size})"))
+                append(colorScheme.bold("Extra"))
+                extra.id?.let { append(" " + colorScheme.cyan("[$it]")) }
+                append(colorScheme.dim(" <${extra.name}>"))
+                if (extra.elements.isNotEmpty()) append(colorScheme.dim(" (${extra.elements.size})"))
             }
         out.println(label)
         if (extra.elements.isNotEmpty()) renderElementChildren(extra.elements)
@@ -126,8 +123,8 @@ class IrPrinter(
     override fun visit(shape: Shape) {
         val label =
             buildString {
-                append(bold(shape::class.simpleName ?: "Shape"))
-                shape.id?.let { append(" " + cyan("[$it]")) }
+                append(colorScheme.bold(shape::class.simpleName ?: "Shape"))
+                shape.id?.let { append(" " + colorScheme.cyan("[$it]")) }
                 append(" fill=").append(formatBrush(shape.fill))
                 if (shape.stroke != Colors.TRANSPARENT) {
                     append(" stroke=").append(formatBrush(shape.stroke))
@@ -137,7 +134,7 @@ class IrPrinter(
                         val cx = formatFloat(shape.cx)
                         val cy = formatFloat(shape.cy)
                         val r = formatFloat(shape.r)
-                        append(dim(" cx=$cx cy=$cy r=$r"))
+                        append(colorScheme.dim(" cx=$cx cy=$cy r=$r"))
                     }
 
                     is Ellipse -> {
@@ -145,7 +142,7 @@ class IrPrinter(
                         val cy = formatFloat(shape.cy)
                         val rx = formatFloat(shape.rx)
                         val ry = formatFloat(shape.ry)
-                        append(dim(" cx=$cx cy=$cy rx=$rx ry=$ry"))
+                        append(colorScheme.dim(" cx=$cx cy=$cy rx=$rx ry=$ry"))
                     }
 
                     is Rect -> {
@@ -153,7 +150,7 @@ class IrPrinter(
                         val y = formatFloat(shape.y)
                         val w = formatFloat(shape.width)
                         val h = formatFloat(shape.height)
-                        append(dim(" x=$x y=$y w=$w h=$h"))
+                        append(colorScheme.dim(" x=$x y=$y w=$w h=$h"))
                     }
 
                     is Line -> {
@@ -161,15 +158,15 @@ class IrPrinter(
                         val y1 = formatFloat(shape.y1)
                         val x2 = formatFloat(shape.x2)
                         val y2 = formatFloat(shape.y2)
-                        append(dim(" ($x1,$y1)->($x2,$y2)"))
+                        append(colorScheme.dim(" ($x1,$y1)->($x2,$y2)"))
                     }
 
                     is Polyline -> {
-                        append(dim(" (${shape.points.size} pts)"))
+                        append(colorScheme.dim(" (${shape.points.size} pts)"))
                     }
 
                     is Polygon -> {
-                        append(dim(" (${shape.points.size} pts)"))
+                        append(colorScheme.dim(" (${shape.points.size} pts)"))
                     }
                 }
             }
@@ -179,9 +176,9 @@ class IrPrinter(
     private fun renderClipPath(cp: ClipPath) {
         val label =
             buildString {
-                append(bold("ClipPath"))
-                cp.id?.let { append(" " + cyan("[$it]")) }
-                append(dim(" (${cp.regions.size})"))
+                append(colorScheme.bold("ClipPath"))
+                cp.id?.let { append(" " + colorScheme.cyan("[$it]")) }
+                append(colorScheme.dim(" (${cp.regions.size})"))
             }
         out.println(label)
         renderChildren(cp.regions.map { path -> { path.accept(this) } })
@@ -190,7 +187,7 @@ class IrPrinter(
     private fun formatCommand(cmd: Command): String =
         when (cmd) {
             is ClosePath -> {
-                green("Z")
+                colorScheme.green("Z").toString()
             }
 
             is MoveTo -> {
@@ -248,44 +245,30 @@ class IrPrinter(
         variant: CommandVariant,
         abs: String,
         rel: String,
-    ): String = green(if (variant == CommandVariant.ABSOLUTE) abs else rel)
+    ): String = colorScheme.green(if (variant == CommandVariant.ABSOLUTE) abs else rel).toString()
 
-    private fun formatBrush(brush: Brush): String =
+    private fun formatBrush(brush: Brush): CharSequence =
         when (brush) {
             is Color -> {
                 val hex = brush.toHexString(HexFormat.ARGB)
-                if (useColor) {
-                    val swatch = "$ESC[38;2;${brush.red.toInt()};${brush.green.toInt()};${brush.blue.toInt()}m■$RESET"
-                    "$swatch ${yellow(hex)}"
-                } else {
-                    hex
-                }
+                val swatch = colorScheme.colorSwatch(brush.red.toInt(), brush.green.toInt(), brush.blue.toInt())
+                if (swatch.isEmpty()) colorScheme.yellow(hex) else "$swatch ${colorScheme.yellow(hex)}"
             }
 
             is LinearGradient -> {
-                dim("linear-gradient(${brush.stops.size} stops)")
+                colorScheme.dim("linear-gradient(${brush.stops.size} stops)")
             }
 
             is RadialGradient -> {
-                dim("radial-gradient(${brush.stops.size} stops)")
+                colorScheme.dim("radial-gradient(${brush.stops.size} stops)")
             }
 
             is SweepGradient -> {
-                dim("sweep-gradient(${brush.stops.size} stops)")
+                colorScheme.dim("sweep-gradient(${brush.stops.size} stops)")
             }
         }
 
     private fun formatPoint(p: Point): String = "${formatFloat(p.x)},${formatFloat(p.y)}"
 
     private fun formatFloat(f: Float): String = if (f % 1f == 0f) f.toInt().toString() else f.toString()
-
-    private fun bold(s: String) = if (useColor) "$ESC[1m$s$RESET" else s
-
-    private fun cyan(s: String) = if (useColor) "$ESC[36m$s$RESET" else s
-
-    private fun green(s: String) = if (useColor) "$ESC[32m$s$RESET" else s
-
-    private fun yellow(s: String) = if (useColor) "$ESC[33m$s$RESET" else s
-
-    private fun dim(s: String) = if (useColor) "$ESC[2m$s$RESET" else s
 }

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinterTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinterTests.kt
@@ -14,6 +14,24 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 
+private object TestColorSchemeStub : IrColorScheme {
+    override fun bold(s: String) = "bold"
+
+    override fun cyan(s: String) = "cyan"
+
+    override fun green(s: String) = "green"
+
+    override fun yellow(s: String) = "yellow"
+
+    override fun dim(s: String) = "dim"
+
+    override fun colorSwatch(
+        red: Int,
+        green: Int,
+        blue: Int,
+    ) = "swatch"
+}
+
 class IrPrinterTests {
     private val path =
         createPath(
@@ -22,11 +40,11 @@ class IrPrinterTests {
     private val graphic = createGraphic(listOf(path))
 
     private fun captureIr(
-        useColor: Boolean,
+        colorScheme: IrColorScheme = PlainColorScheme,
         block: (IrPrinter) -> Unit,
     ): String {
         val baos = ByteArrayOutputStream()
-        IrPrinter(PrintStream(baos, true, StandardCharsets.UTF_8), useColor).also(block)
+        IrPrinter(PrintStream(baos, true, StandardCharsets.UTF_8), colorScheme).also(block)
         return baos.toString(StandardCharsets.UTF_8)
     }
 
@@ -46,27 +64,20 @@ class IrPrinterTests {
     }
 
     @Test
-    fun `plain mode produces no ansi escape codes`() {
-        val esc = Char(0x1B).toString()
-        assertThat(captureIr(false) { it.visit(graphic) }).doesNotContain(esc)
-    }
-
-    @Test
     fun `color mode produces ansi escape codes`() {
-        val esc = Char(0x1B).toString()
-        assertThat(captureIr(true) { it.visit(graphic) }).contains(esc)
+        assertThat(captureIr(TestColorSchemeStub) { it.visit(graphic) }).contains("dim")
     }
 
     @Test
     fun `graphic id is shown in brackets`() {
         val withId = createGraphic(id = "myicon")
-        assertThat(captureIr(false) { it.visit(withId) }).contains("[myicon]")
+        assertThat(captureIr { it.visit(withId) }).contains("[myicon]")
     }
 
     @Test
     fun `path id is shown in brackets`() {
         val g = createGraphic(listOf(createPath(id = "mypath")))
-        assertThat(captureIr(false) { it.visit(g) }).contains("[mypath]")
+        assertThat(captureIr { it.visit(g) }).contains("[mypath]")
     }
 
     @Test
@@ -77,7 +88,7 @@ class IrPrinterTests {
     @Test
     fun `multiple children use branch and corner connectors`() {
         val g = createGraphic(listOf(path, path))
-        val output = captureIr(false) { it.visit(g) }
+        val output = captureIr { it.visit(g) }
         assertThat(output).contains("├──")
         assertThat(output).contains("└──")
     }
@@ -85,6 +96,6 @@ class IrPrinterTests {
     @Test
     fun `group appears in output`() {
         val g = createGraphic(listOf(Group(listOf(path))))
-        assertThat(captureIr(false) { it.visit(g) }).contains("Group")
+        assertThat(captureIr { it.visit(g) }).contains("Group")
     }
 }

--- a/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinterTests.kt
+++ b/vgo-core/src/test/kotlin/com/jzbrooks/vgo/core/util/ir/IrPrinterTests.kt
@@ -1,0 +1,90 @@
+package com.jzbrooks.vgo.core.util.ir
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import com.jzbrooks.vgo.core.graphic.Group
+import com.jzbrooks.vgo.core.graphic.command.CommandVariant
+import com.jzbrooks.vgo.core.graphic.command.MoveTo
+import com.jzbrooks.vgo.core.util.element.createGraphic
+import com.jzbrooks.vgo.core.util.element.createPath
+import com.jzbrooks.vgo.core.util.math.Point
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+
+class IrPrinterTests {
+    private val path =
+        createPath(
+            commands = listOf(MoveTo(CommandVariant.ABSOLUTE, listOf(Point(10f, 20f)))),
+        )
+    private val graphic = createGraphic(listOf(path))
+
+    private fun captureIr(
+        useColor: Boolean,
+        block: (IrPrinter) -> Unit,
+    ): String {
+        val baos = ByteArrayOutputStream()
+        IrPrinter(PrintStream(baos, true, StandardCharsets.UTF_8), useColor).also(block)
+        return baos.toString(StandardCharsets.UTF_8)
+    }
+
+    @Test
+    fun `asIr output contains root label`() {
+        assertThat(graphic.asIr()).contains("Graphic")
+    }
+
+    @Test
+    fun `asIr output contains path`() {
+        assertThat(graphic.asIr()).contains("Path")
+    }
+
+    @Test
+    fun `asIr output contains moveto command letter`() {
+        assertThat(graphic.asIr()).contains("M")
+    }
+
+    @Test
+    fun `plain mode produces no ansi escape codes`() {
+        val esc = Char(0x1B).toString()
+        assertThat(captureIr(false) { it.visit(graphic) }).doesNotContain(esc)
+    }
+
+    @Test
+    fun `color mode produces ansi escape codes`() {
+        val esc = Char(0x1B).toString()
+        assertThat(captureIr(true) { it.visit(graphic) }).contains(esc)
+    }
+
+    @Test
+    fun `graphic id is shown in brackets`() {
+        val withId = createGraphic(id = "myicon")
+        assertThat(captureIr(false) { it.visit(withId) }).contains("[myicon]")
+    }
+
+    @Test
+    fun `path id is shown in brackets`() {
+        val g = createGraphic(listOf(createPath(id = "mypath")))
+        assertThat(captureIr(false) { it.visit(g) }).contains("[mypath]")
+    }
+
+    @Test
+    fun `single child uses corner connector`() {
+        assertThat(graphic.asIr()).contains("└──")
+    }
+
+    @Test
+    fun `multiple children use branch and corner connectors`() {
+        val g = createGraphic(listOf(path, path))
+        val output = captureIr(false) { it.visit(g) }
+        assertThat(output).contains("├──")
+        assertThat(output).contains("└──")
+    }
+
+    @Test
+    fun `group appears in output`() {
+        val g = createGraphic(listOf(Group(listOf(path))))
+        assertThat(captureIr(false) { it.visit(g) }).contains("Group")
+    }
+}

--- a/vgo/api/vgo.api
+++ b/vgo/api/vgo.api
@@ -5,8 +5,8 @@ public final class com/jzbrooks/vgo/Vgo {
 
 public final class com/jzbrooks/vgo/Vgo$Options {
 	public fun <init> ()V
-	public fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;)V
+	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/util/List;
@@ -14,18 +14,29 @@ public final class com/jzbrooks/vgo/Vgo$Options {
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Z
-	public final fun component8 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/jzbrooks/vgo/Vgo$Options;
-	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/Vgo$Options;ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/jzbrooks/vgo/Vgo$Options;
+	public final fun component8 ()Lcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;
+	public final fun copy (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;)Lcom/jzbrooks/vgo/Vgo$Options;
+	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/Vgo$Options;ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;ILjava/lang/Object;)Lcom/jzbrooks/vgo/Vgo$Options;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDumpIr ()Lcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;
 	public final fun getFormat ()Ljava/lang/String;
 	public final fun getIndent ()Ljava/lang/Integer;
 	public final fun getInput ()Ljava/util/List;
 	public final fun getNoOptimization ()Z
-	public final fun getOnGraphicReady ()Lkotlin/jvm/functions/Function1;
 	public final fun getOutput ()Ljava/util/List;
 	public final fun getPrintStats ()Z
 	public final fun getPrintVersion ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/jzbrooks/vgo/Vgo$Options$IrDumpOptions {
+	public fun <init> (Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;)V
+	public final fun component1 ()Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;
+	public final fun copy (Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;)Lcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;
+	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;ILjava/lang/Object;)Lcom/jzbrooks/vgo/Vgo$Options$IrDumpOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorScheme ()Lcom/jzbrooks/vgo/core/util/ir/IrColorScheme;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/vgo/api/vgo.api
+++ b/vgo/api/vgo.api
@@ -5,8 +5,8 @@ public final class com/jzbrooks/vgo/Vgo {
 
 public final class com/jzbrooks/vgo/Vgo$Options {
 	public fun <init> ()V
-	public fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Z)V
-	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/util/List;
@@ -14,13 +14,15 @@ public final class com/jzbrooks/vgo/Vgo$Options {
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Z
-	public final fun copy (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Z)Lcom/jzbrooks/vgo/Vgo$Options;
-	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/Vgo$Options;ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZILjava/lang/Object;)Lcom/jzbrooks/vgo/Vgo$Options;
+	public final fun component8 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Lcom/jzbrooks/vgo/Vgo$Options;
+	public static synthetic fun copy$default (Lcom/jzbrooks/vgo/Vgo$Options;ZZLjava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/jzbrooks/vgo/Vgo$Options;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFormat ()Ljava/lang/String;
 	public final fun getIndent ()Ljava/lang/Integer;
 	public final fun getInput ()Ljava/util/List;
 	public final fun getNoOptimization ()Z
+	public final fun getOnGraphicReady ()Lkotlin/jvm/functions/Function1;
 	public final fun getOutput ()Ljava/util/List;
 	public final fun getPrintStats ()Z
 	public final fun getPrintVersion ()Z

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/Vgo.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/Vgo.kt
@@ -5,6 +5,7 @@ package com.jzbrooks.vgo
 import com.jzbrooks.BuildConstants
 import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.util.ExperimentalVgoApi
+import com.jzbrooks.vgo.core.util.ir.IrPrinter
 import com.jzbrooks.vgo.iv.ImageVector
 import com.jzbrooks.vgo.iv.ImageVectorOptimizationRegistry
 import com.jzbrooks.vgo.iv.ImageVectorWriter
@@ -171,8 +172,12 @@ class Vgo(
             }
         }
 
-        if (options.onGraphicReady != null) {
-            if (graphic != null) options.onGraphicReady.invoke(graphic)
+        if (options.dumpIr != null) {
+            if (graphic != null) {
+                IrPrinter(useColor = options.dumpIr === Options.IrDumpMode.Color).visit(graphic)
+            } else {
+                System.err.println("Warning: Unable to dump IR. Graphic could not be parsed.")
+            }
             return
         }
 
@@ -410,6 +415,11 @@ class Vgo(
         val indent: Int? = null,
         val format: String? = null,
         val noOptimization: Boolean = false,
-        val onGraphicReady: ((Graphic) -> Unit)? = null,
-    )
+        val dumpIr: IrDumpMode? = null,
+    ) {
+        enum class IrDumpMode {
+            Color,
+            Plain,
+        }
+    }
 }

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/Vgo.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/Vgo.kt
@@ -3,6 +3,7 @@
 package com.jzbrooks.vgo
 
 import com.jzbrooks.BuildConstants
+import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.util.ExperimentalVgoApi
 import com.jzbrooks.vgo.iv.ImageVector
 import com.jzbrooks.vgo.iv.ImageVectorOptimizationRegistry
@@ -168,6 +169,11 @@ class Vgo(
 
                 optimizationRegistry?.apply(graphic)
             }
+        }
+
+        if (options.onGraphicReady != null) {
+            if (graphic != null) options.onGraphicReady.invoke(graphic)
+            return
         }
 
         // Format conversions should always write the converted output regardless of size,
@@ -404,5 +410,6 @@ class Vgo(
         val indent: Int? = null,
         val format: String? = null,
         val noOptimization: Boolean = false,
+        val onGraphicReady: ((Graphic) -> Unit)? = null,
     )
 }

--- a/vgo/src/main/kotlin/com/jzbrooks/vgo/Vgo.kt
+++ b/vgo/src/main/kotlin/com/jzbrooks/vgo/Vgo.kt
@@ -5,6 +5,7 @@ package com.jzbrooks.vgo
 import com.jzbrooks.BuildConstants
 import com.jzbrooks.vgo.core.graphic.Graphic
 import com.jzbrooks.vgo.core.util.ExperimentalVgoApi
+import com.jzbrooks.vgo.core.util.ir.IrColorScheme
 import com.jzbrooks.vgo.core.util.ir.IrPrinter
 import com.jzbrooks.vgo.iv.ImageVector
 import com.jzbrooks.vgo.iv.ImageVectorOptimizationRegistry
@@ -172,9 +173,9 @@ class Vgo(
             }
         }
 
-        if (options.dumpIr != null) {
+        options.dumpIr?.let { options ->
             if (graphic != null) {
-                IrPrinter(useColor = options.dumpIr === Options.IrDumpMode.Color).visit(graphic)
+                IrPrinter(colorScheme = options.colorScheme).visit(graphic)
             } else {
                 System.err.println("Warning: Unable to dump IR. Graphic could not be parsed.")
             }
@@ -415,11 +416,10 @@ class Vgo(
         val indent: Int? = null,
         val format: String? = null,
         val noOptimization: Boolean = false,
-        val dumpIr: IrDumpMode? = null,
+        val dumpIr: IrDumpOptions? = null,
     ) {
-        enum class IrDumpMode {
-            Color,
-            Plain,
-        }
+        data class IrDumpOptions(
+            val colorScheme: IrColorScheme,
+        )
     }
 }


### PR DESCRIPTION
Adds a quick way to see the structure of a graphic

```
% vgo vgo/src/test/resources/simple_heart.xml --print-ir
VectorDrawable [vector] (100x100)
└── Path [path] fill=#00000000 stroke=#ff0000 sw=1 (11 cmds)
    ├── M 10,30
    ├── a 20.008137,20.008137 0 0,1 5.858,-14.142
    ├── A 20.008137,20.008137 0 0,1 30,10
    ├── a 20.008123,20.008123 0 0,1 14.141998,5.858
    ├── A 20.008133,20.008133 0 0,1 50,30
    ├── a 20.008135,20.008135 0 0,1 5.8580017,-14.142
    ├── A 20.008116,20.008116 0 0,1 70,10
    ├── a 20.008123,20.008123 0 0,1 14.141998,5.858
    ├── A 20.008133,20.008133 0 0,1 90,30
    ├── q 0,30 -40,60
    └── Q 10,60 10,30
```